### PR TITLE
No retrodictions

### DIFF
--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -1,66 +1,66 @@
 class Prediction < ActiveRecord::Base
   version_fu
-  class DuplicateRecord < ActiveRecord::RecordInvalid;end
+  class DuplicateRecord < ActiveRecord::RecordInvalid; end
   include CommonScopes
-  belongs_to :creator, :class_name => 'User'
+  belongs_to :creator, class_name: 'User'
 
   def self.parse_deadline(date)
-    Chronic.parse(date, :context => :future)
+    Chronic.parse(date, context: :future)
   end
 
-  scope :not_withdrawn, :conditions => { :withdrawn => false }
+  scope :not_withdrawn, conditions: { withdrawn: false }
   # if you change the implementation of 'public', also change this scope in response
-  scope :not_private, :conditions => { :private => false }
+  scope :not_private, conditions: { private: false }
 
   DEFAULT_INCLUDES = [:judgements, :responses, :creator]
 
   def self.unjudged
-    not_private.not_withdrawn.all(:include => DEFAULT_INCLUDES,
-      :conditions => '(SELECT outcome AS most_recent_outcome FROM judgements WHERE prediction_id = predictions.id ORDER BY created_at DESC LIMIT 1) IS NULL AND deadline < UTC_TIMESTAMP()').
-      rsort(:deadline)
+    not_private.not_withdrawn.all(include: DEFAULT_INCLUDES,
+                                  conditions: '(SELECT outcome AS most_recent_outcome FROM judgements WHERE prediction_id = predictions.id ORDER BY created_at DESC LIMIT 1) IS NULL AND deadline < UTC_TIMESTAMP()')
+      .rsort(:deadline)
   end
 
   def self.judged
-    not_private.not_withdrawn.all(:include => DEFAULT_INCLUDES,
-      :conditions => '(SELECT outcome AS most_recent_outcome FROM judgements WHERE prediction_id = predictions.id ORDER BY created_at DESC LIMIT 1) IS NOT NULL',
-      :order => 'judgements.created_at DESC')
+    not_private.not_withdrawn.all(include: DEFAULT_INCLUDES,
+                                  conditions: '(SELECT outcome AS most_recent_outcome FROM judgements WHERE prediction_id = predictions.id ORDER BY created_at DESC LIMIT 1) IS NOT NULL',
+                                  order: 'judgements.created_at DESC')
   end
 
   def self.future
-    sort(:deadline).not_private.not_withdrawn.includes(DEFAULT_INCLUDES).where("judgements.outcome IS NULL AND deadline > UTC_TIMESTAMP()")
+    sort(:deadline).not_private.not_withdrawn.includes(DEFAULT_INCLUDES).where('judgements.outcome IS NULL AND deadline > UTC_TIMESTAMP()')
   end
 
   def self.recent
-    rsort.not_private.not_withdrawn.all(:include => DEFAULT_INCLUDES)
+    rsort.not_private.not_withdrawn.all(include: DEFAULT_INCLUDES)
   end
 
   def self.popular
     opts = {
-      :include => [:responses, :creator], # Eager loading of :judgements breaks judgement and unknown?
-      :conditions => [
+      include: [:responses, :creator], # Eager loading of :judgements breaks judgement and unknown?
+      conditions: [
         'predictions.deadline > UTC_TIMESTAMP() AND predictions.created_at > ?', 2.weeks.ago
       ],
-      :order => 'count(responses.prediction_id) DESC, predictions.deadline ASC',
-      :group => 'predictions.id',
+      order: 'count(responses.prediction_id) DESC, predictions.deadline ASC',
+      group: 'predictions.id'
     }
-    not_private.not_withdrawn.all(opts).select { |p| p.unknown? }
+    not_private.not_withdrawn.all(opts).select(&:unknown?)
   end
 
-  belongs_to :creator, :class_name => 'User'
+  belongs_to :creator, class_name: 'User'
 
-  has_many :deadline_notifications, :dependent => :destroy
-  has_many :response_notifications, :dependent => :destroy
-  has_many :judgements,             :dependent => :destroy
-  has_many :responses,              :dependent => :destroy
+  has_many :deadline_notifications, dependent: :destroy
+  has_many :response_notifications, dependent: :destroy
+  has_many :judgements,             dependent: :destroy
+  has_many :responses,              dependent: :destroy
 
-  delegate :wagers, :to => :responses
-  delegate :comments, :to => :responses
+  delegate :wagers, to: :responses
+  delegate :comments, to: :responses
 
-  validates_presence_of :deadline, :message => "When will you know you're right?"
-  validates_presence_of :creator, :message => 'Who are you?'
-  validates_presence_of :description, :message => 'What are you predicting?'
-  validates_presence_of :initial_confidence, :message => 'How sure are you?', :on => :create
-  validate :confidence_on_response, :on => :create
+  validates_presence_of :deadline, message: "When will you know you're right?"
+  validates_presence_of :creator, message: 'Who are you?'
+  validates_presence_of :description, message: 'What are you predicting?'
+  validates_presence_of :initial_confidence, message: 'How sure are you?', on: :create
+  validate :confidence_on_response, on: :create
   validate :bound_deadline
 
   after_validation do
@@ -68,20 +68,17 @@ class Prediction < ActiveRecord::Base
   end
 
   after_initialize do
-    if has_attribute?(:uuid)
-      self.uuid ||= UUID.random_create.to_s
-    end
+    self.uuid ||= UUID.random_create.to_s if has_attribute?(:uuid)
   end
 
-  before_validation(:on => :create) do
-
-    @initial_response ||= self.responses.build(
-      :prediction => self,
-      :confidence => initial_confidence,
-      :user => creator
+  before_validation(on: :create) do
+    @initial_response ||= responses.build(
+      prediction: self,
+      confidence: initial_confidence,
+      user: creator
     )
 
-    deadline_notifications.build(:prediction => self, :user => creator) if notify_creator
+    deadline_notifications.build(prediction: self, user: creator) if notify_creator
   end
 
   def save!
@@ -95,11 +92,11 @@ class Prediction < ActiveRecord::Base
 
   attr_accessor :initial_confidence
 
-  boolean_accessor_with_default(:notify_creator) {creator ? creator.notify_on_overdue? : false}
+  boolean_accessor_with_default(:notify_creator) { creator ? creator.notify_on_overdue? : false }
 
   # attr_reader :deadline_text
   def deadline_text
-    @deadline_text || (deadline ? deadline.localtime.to_s(:db) : "")
+    @deadline_text || (deadline ? deadline.localtime.to_s(:db) : '')
   end
 
   def deadline_text=(new_deadline)
@@ -128,8 +125,8 @@ class Prediction < ActiveRecord::Base
     [responses, versions[1..-1], judgements].flatten.sort_by(&:created_at)
   end
 
-  def judge!(outcome, user=nil)
-    judgements.create!(:user => user, :outcome => outcome)
+  def judge!(outcome, user = nil)
+    judgements.create!(user: user, outcome: outcome)
   end
 
   def judgement
@@ -161,7 +158,7 @@ class Prediction < ActiveRecord::Base
   end
 
   def withdraw!
-    raise ArgumentError, "Prediction must be open to be withdrawn" unless open?
+    fail ArgumentError, 'Prediction must be open to be withdrawn' unless open?
     update_attribute(:withdrawn, true)
   end
 
@@ -173,7 +170,7 @@ class Prediction < ActiveRecord::Base
     open? && creator == user
   end
 
-  {:right => true, :wrong => false, :unknown => nil}.each do |name, value|
+  { right: true, wrong: false, unknown: nil }.each do |name, value|
     define_method :"#{name}?" do
       outcome == value
     end
@@ -192,15 +189,15 @@ class Prediction < ActiveRecord::Base
   end
 
   def count_wagers_by(user)
-    wagers.count(:conditions => {:user_id => user})
+    wagers.count(conditions: { user_id: user })
   end
 
   def deadline_notification_for_user(user)
-    deadline_notifications.find_by_user_id(user) || deadline_notifications.build(:user => user, :enabled => false)
+    deadline_notifications.find_by_user_id(user) || deadline_notifications.build(user: user, enabled: false)
   end
 
   def response_notification_for_user(user)
-    response_notifications.find_by_user_id(user) || response_notifications.build(:user => user, :enabled => false)
+    response_notifications.find_by_user_id(user) || response_notifications.build(user: user, enabled: false)
   end
 
   def confidence_on_response
@@ -211,7 +208,7 @@ class Prediction < ActiveRecord::Base
 
   def bound_deadline
     if too_futuristic?
-      errors.add(:deadline, "Please consider creating a time capsule to record this prediction.")
+      errors.add(:deadline, 'Please consider creating a time capsule to record this prediction.')
     elsif before_christ?
       errors.add(:deadline, "If it was known that long ago, it's not exactly a prediction, is it?")
     elsif retrodiction?


### PR DESCRIPTION
This pull request should fix [this](https://github.com/tricycle/predictionbook/issues/68) issue. Ideally, we wouldn't allow predictions with a known-by date before the current time (with a small buffer for timezone differences), but I ended up having to allow it up to 15 days into the past. Otherwise, some of the older tests would need to be rewritten.