### PR TITLE
Update exception notifier config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,9 @@ PredictionBook2::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  config.middleware.use ExceptionNotifier, :email_prefix => "[Prediction Book] ",
-                                           :sender_address => %{"Exception Notifier" <system@predictionbook.com>},
-                                           :exception_recipients => %w{predictionbook.production.errors@trikeapps.com}
+  config.middleware.use ExceptionNotification::Rack, :email => {
+    :email_prefix => "[Prediction Book] ",
+    :sender_address => %{"Exception Notifier" <system@predictionbook.com>},
+    :exception_recipients => %w{predictionbook.production.errors@trikeapps.com}
+  }
 end


### PR DESCRIPTION
I had make this change to get the production environment running. Looks like it's [due to updating exception_notifier to 4.x](https://github.com/smartinez87/exception_notification#user-content-upgrading-to-4x-version)