### PR TITLE
Extend JSON API

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,6 +7,13 @@ Parameter name | Value   | Description
 api_token      | string  | A token that identifies a unique user
 limit          | integer | The maximum number of predictions that will be returned (optional)
 
+GET http://predictionbook.com/api/predictions/:id
+
+Parameter name | Value   | Description
+---------------| --------|------------
+api_token      | string  | A token that identifies a unique user
+id             | integer | The prediction id
+
 POST  http://predictionbook.com/api/predictions
 
 Parameter name                | Value   | Description

--- a/API.md
+++ b/API.md
@@ -1,6 +1,6 @@
 # JSON API
 
-GET  http://predictionbook.com/api/predictions
+GET http://predictionbook.com/api/predictions
 
 Parameter name | Value   | Description
 ---------------| --------|------------
@@ -14,12 +14,21 @@ Parameter name | Value   | Description
 api_token      | string  | A token that identifies a unique user
 id             | integer | The prediction id
 
-POST  http://predictionbook.com/api/predictions
+POST http://predictionbook.com/api/predictions
 
 Parameter name                | Value   | Description
 ------------------------------| --------|------------
 api_token                     | string  | A token that identifies a unique user
 prediction[description]       | string  | Your prediction statement
 prediction[deadline]          | date    | when it will/won't have happened
-prediction[initial_confidence]| integer | a probability assignment
-prediction[private]           | boolean | true if you want it to be private (optional)
+prediction[initial_confidence]| integer | A probability assignment
+prediction[private]           | boolean | True if you want it to be private (optional)
+
+PUT http://predictionbook.com/api/predictions/:id
+
+Parameter name                | Value   | Description
+------------------------------| --------|------------
+api_token                     | string  | A token that identifies a unique user
+prediction[description]       | string  | Your prediction statement
+prediction[deadline]          | date    | When it will/won't have happened
+prediction[private]           | boolean | True if you want it to be private (optional)

--- a/app/controllers/api/predictions_controller.rb
+++ b/app/controllers/api/predictions_controller.rb
@@ -46,14 +46,12 @@ module Api
 
     def authorize_to_see_prediction
       unless @prediction.public? || @user.authorized_for(@prediction)
-        render json: unauthorized_user_message, status: :unauthorized
+        raise UnauthorizedRequest
       end
     end
 
     def authorize_to_update_prediction
-      unless @user.authorized_for(@prediction)
-        render json: unauthorized_user_message, status: :unauthorized
-      end
+      raise UnauthorizedRequest unless @user.authorized_for(@prediction)
     end
 
     def build_new_prediction
@@ -80,13 +78,6 @@ module Api
 
     def invalid_api_message
       { error: 'invalid API token', status: :unauthorized }
-    end
-
-    def unauthorized_user_message
-      {
-        error: 'user is unauthorized for this prediction',
-        status: :unauthorized
-      }
     end
 
     def valid_params_and_user?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,22 +2,34 @@
 # Likewise, all the methods added will be available for all controllers.
 
 class ApplicationController < ActionController::Base
+  class UnauthorizedRequest < StandardError
+  end
+
   helper :all # include all helpers, all the time
   unloadable # restful_authentication breaks rails class reloading in dev mode, a fix would be appreciated immensely
   include AuthenticatedSystem
-  
+
   before_filter :set_timezone, :clear_return_to, :login_via_token
 
   # See ActionController::RequestForgeryProtection for details
   # Uncomment the :secret if you're not using the cookie session store
   protect_from_forgery # :secret => 'c4ec086ac06ce802c8f49e28cc1e8943'
-  
-  # See ActionController::Base for details 
+
+  # See ActionController::Base for details
   # Uncomment this to filter the contents of submitted sensitive data parameters
-  # from your application log (in this case, all fields with names like "password"). 
+  # from your application log (in this case, all fields with names like "password").
   # filter_parameter_logging :password
-  
+
+  rescue_from UnauthorizedRequest, with: :handle_unauthorised_request
+
+  protected
+
+  def handle_unauthorised_request
+    render json: unauthorized_user_message, status: :unauthorized
+  end
+
   private
+
   def set_timezone
     if logged_in? && !current_user.timezone.blank?
       Time.zone = current_user.timezone
@@ -26,17 +38,24 @@ class ApplicationController < ActionController::Base
     end
     Chronic.time_class = Time.zone
   end
-  
+
   def clear_return_to
     session[:return_to] = nil
   end
-  
+
   def login_via_token
     if token = params[:token]
       DeadlineNotification.use_token!(token) do |dn|
         self.current_user = dn.user
       end
-      redirect_to # get rid of token in url so if it is copied and pasted it's not propagated 
+      redirect_to # get rid of token in url so if it is copied and pasted it's not propagated
     end
+  end
+
+  def unauthorized_user_message
+    {
+      error: 'user is unauthorized to view/edit this private prediction',
+      status: :unauthorized
+    }
   end
 end

--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -216,6 +216,10 @@ class Prediction < ActiveRecord::Base
     end
   end
 
+  def public?
+    not private?
+  end
+
   private
 
   def too_futuristic?

--- a/spec/controllers/api/predictions_controller_spec.rb
+++ b/spec/controllers/api/predictions_controller_spec.rb
@@ -6,10 +6,6 @@ describe Api::PredictionsController, type: :controller do
   let(:prediction) { build(:prediction) }
   let(:predicitons) { [prediction] }
 
-  before do
-    controller.stub(:set_timezone)
-  end
-
   describe 'GET /predictions' do
     context 'with valid API token' do
       let(:user_with_token) do
@@ -19,10 +15,9 @@ describe Api::PredictionsController, type: :controller do
       let(:recent) { double(:recent_predictions) }
 
       before do
-        User.stub(:find_by_api_token).and_return(user_with_token)
+        allow(User).to receive(:find_by_api_token).and_return(user_with_token)
 
-        Prediction.should_receive(:limit)
-          .with(100)
+        allow(Prediction).to receive(:limit).with(100)
           .and_return(double(:collection, recent: recent))
 
         get :index, api_token: user_with_token.api_token
@@ -55,7 +50,8 @@ describe Api::PredictionsController, type: :controller do
       let(:user_with_email) { build(:user_with_email, api_token: token) }
 
       before do
-        User.stub(:find_by_api_token).with(token).and_return(user_with_email)
+        allow(User).to receive(:find_by_api_token)
+          .with(token).and_return(user_with_email)
       end
 
       it 'should create a new prediction' do

--- a/spec/controllers/api/predictions_controller_spec.rb
+++ b/spec/controllers/api/predictions_controller_spec.rb
@@ -118,20 +118,16 @@ describe Api::PredictionsController, type: :controller do
     let(:new_prediction_params) do
       { description: 'The world definitely will not end tomorrow!' }
     end
-
-    before do
-      @user = valid_user(api_token: token)
-      @user.save
-      @prediction = valid_prediction(creator: @user)
-      @prediction.save
-    end
+    let(:user) { valid_user(api_token: token) }
+    let(:prediction) { valid_prediction(creator: user) }
+    before { prediction.save }
 
     context 'with valid API token' do
       context 'authorized user' do
         before do
           put :update,
-              api_token: @user.api_token,
-              id: @prediction.id,
+              api_token: user.api_token,
+              id: prediction.id,
               prediction: new_prediction_params
         end
 
@@ -140,9 +136,9 @@ describe Api::PredictionsController, type: :controller do
 
         it 'updates the existing prediction' do
           description = new_prediction_params[:description]
-          @prediction.reload
+          prediction.reload
 
-          expect(@prediction.description).to eq(description)
+          expect(prediction.description).to eq(description)
         end
       end
 
@@ -150,7 +146,7 @@ describe Api::PredictionsController, type: :controller do
         before do
           put :update,
               api_token: 'fake-token',
-              id: @prediction.id,
+              id: prediction.id,
               prediction: new_prediction_params
         end
 
@@ -163,7 +159,7 @@ describe Api::PredictionsController, type: :controller do
       before do
         put :update,
             api_token: 'fake-token',
-            id: @prediction.id,
+            id: prediction.id,
             prediction: new_prediction_params
       end
 


### PR DESCRIPTION
This refactors and extends the JSON API to include endpoints for GET /predictions/:id and PUT /predictions/:id. I'll get to the rest of the endpoints a little later on. 

Please let me know if anything needs improvement. Thanks!