### PR TITLE
Added Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'devise'
 # Models
 gem 'chronic'
 gem 'uuidtools'
+gem 'kaminari'
 
 # Views
 gem 'RedCloth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,9 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (3.16.14.15)
@@ -310,6 +313,7 @@ DEPENDENCIES
   honeypot-captcha
   htmlentities
   jquery-rails
+  kaminari
   launchy
   mysql2
   pry
@@ -333,4 +337,4 @@ DEPENDENCIES
   wirble
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/app/assets/stylesheets/predictions.scss
+++ b/app/assets/stylesheets/predictions.scss
@@ -33,21 +33,21 @@ ul#responses, #responses ul {
   font-style: italic;
   word-wrap: break-word;
 }
-#judgement .withdraw form { 
-  float: left; 
-  padding: 0; 
+#judgement .withdraw form {
+  float: left;
+  padding: 0;
 }
 
 .prediction .private.status {
   color: black;
 }
 
-li.prediction p, li p.prediction { 
-  margin: 0; 
-  display: inline; 
+li.prediction p, li p.prediction {
+  margin: 0;
+  display: inline;
 }
-li.prediction p.description { 
-  display: block; 
+li.prediction p.description {
+  display: block;
 }
 li.prediction {
   padding-bottom:0.5em;
@@ -126,3 +126,8 @@ li.response, li.change, .comment {
 .statistics table td { text-align: center; padding: 4px 8px; border: 1px dashed #CCC; border-top: none;border-top:none;}
 .statistics table { width: auto; margin:1em 0.5em 1em 18px; font-size:90%; border-collapse:collapse; }
 .statistics img { margin-right:6px; }
+
+.pagination {
+  font-size: 1.2em;
+  text-align: center;
+}

--- a/app/controllers/deadline_notifications_controller.rb
+++ b/app/controllers/deadline_notifications_controller.rb
@@ -3,13 +3,9 @@ class DeadlineNotificationsController < NotificationsController
     @user = User.find_by_login(params[:user_id]) || User.find_by_id(params[:user_id])
 
     @pending = @user.deadline_notifications.sendable.sort
-    @pending = Kaminari.paginate_array(@pending).page(params[:page]).per(20)
     @waiting = @user.deadline_notifications.unsent.enabled.unknown.sort
-    @waiting = Kaminari.paginate_array(@waiting).page(params[:page]).per(20)
     @known = @user.deadline_notifications.unsent.enabled.known.rsort(:judged_at)
-    @known = Kaminari.paginate_array(@known).page(params[:page]).per(20)
     @sent = @user.deadline_notifications.sent.rsort(:deadline)
-    @sent = Kaminari.paginate_array(@sent).page(params[:page]).per(20)
   end
 
   def notification_type

--- a/app/controllers/deadline_notifications_controller.rb
+++ b/app/controllers/deadline_notifications_controller.rb
@@ -3,9 +3,13 @@ class DeadlineNotificationsController < NotificationsController
     @user = User.find_by_login(params[:user_id]) || User.find_by_id(params[:user_id])
 
     @pending = @user.deadline_notifications.sendable.sort
+    @pending = Kaminari.paginate_array(@pending).page(params[:page]).per(20)
     @waiting = @user.deadline_notifications.unsent.enabled.unknown.sort
+    @waiting = Kaminari.paginate_array(@waiting).page(params[:page]).per(20)
     @known = @user.deadline_notifications.unsent.enabled.known.rsort(:judged_at)
+    @known = Kaminari.paginate_array(@known).page(params[:page]).per(20)
     @sent = @user.deadline_notifications.sent.rsort(:deadline)
+    @sent = Kaminari.paginate_array(@sent).page(params[:page]).per(20)
   end
 
   def notification_type

--- a/app/controllers/predictions_controller.rb
+++ b/app/controllers/predictions_controller.rb
@@ -59,7 +59,7 @@ class PredictionsController < ApplicationController
   def index
     @title = 'Recent Predictions'
     @filter = 'recent'
-    @predictions = Prediction.recent(limit: 100)
+    @predictions = Prediction.recent.page params[:page]
     @show_statistics = true
   end
 

--- a/app/controllers/predictions_controller.rb
+++ b/app/controllers/predictions_controller.rb
@@ -78,7 +78,7 @@ class PredictionsController < ApplicationController
   def judged
     @title = 'Judged Predictions'
     @filter = 'judged'
-    @predictions = Prediction.judged(limit: 100)
+    @predictions = Prediction.judged.page params[:page]
     @show_statistics = true
     render action: 'index'
   end
@@ -86,14 +86,14 @@ class PredictionsController < ApplicationController
   def unjudged
     @title = 'Unjudged Predictions'
     @filter = 'unjudged'
-    @predictions = Prediction.unjudged(limit: 100)
+    @predictions = Prediction.unjudged.page params[:page]
     render action: 'index'
   end
 
   def future
     @title = 'Upcoming Predictions'
     @filter = 'future'
-    @predictions = Prediction.future(limit: 100)
+    @predictions = Prediction.future.page params[:page]
     render action: 'index'
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
     @title       = "Most recent predictions by #{@user}"
     @predictions = @user.predictions
     @predictions = @predictions.not_private unless user_is_current_user?
-    @predictions = @predictions.limit(100)
+    @predictions = @predictions.page params[:page]
   end
 
   def update

--- a/app/views/deadline_notifications/index.html.erb
+++ b/app/views/deadline_notifications/index.html.erb
@@ -3,19 +3,23 @@
 <%- unless @pending.empty? -%>
 <h2 id='pending'>Waiting to be sent</h2>
 <ul class='future'><%= render :partial => 'list', :locals => {:deadline_notifications => @pending} -%></ul>
+<p class="pagination"><%= paginate @pending %></p>
 <%- end -%>
 
 <%- unless @waiting.empty? -%>
 <h2 id='waiting'>Waiting for deadline</h2>
 <ul class='future'><%= render :partial => 'list', :locals => {:deadline_notifications => @waiting} -%></ul>
+<p class="pagination"><%= paginate @waiting %></p>
 <%- end -%>
 
 <%- unless @known.empty? -%>
 <h2 id='unsent'>Judged before deadline</h2>
 <ul class='judged'><%= render :partial => 'list', :locals => {:deadline_notifications => @known} -%></ul>
+<p class="pagination"><%= paginate @known %></p>
 <%- end -%>
 
 <%- unless @sent.empty? -%>
 <h2 id='sent'>Sent</h2>
 <ul class='future'><%= render :partial => 'list', :locals => {:deadline_notifications => @sent} -%></ul>
+<p class="pagination"><%= paginate @sent %></p>
 <%- end -%>

--- a/app/views/deadline_notifications/index.html.erb
+++ b/app/views/deadline_notifications/index.html.erb
@@ -3,23 +3,19 @@
 <%- unless @pending.empty? -%>
 <h2 id='pending'>Waiting to be sent</h2>
 <ul class='future'><%= render :partial => 'list', :locals => {:deadline_notifications => @pending} -%></ul>
-<p class="pagination"><%= paginate @pending %></p>
 <%- end -%>
 
 <%- unless @waiting.empty? -%>
 <h2 id='waiting'>Waiting for deadline</h2>
 <ul class='future'><%= render :partial => 'list', :locals => {:deadline_notifications => @waiting} -%></ul>
-<p class="pagination"><%= paginate @waiting %></p>
 <%- end -%>
 
 <%- unless @known.empty? -%>
 <h2 id='unsent'>Judged before deadline</h2>
 <ul class='judged'><%= render :partial => 'list', :locals => {:deadline_notifications => @known} -%></ul>
-<p class="pagination"><%= paginate @known %></p>
 <%- end -%>
 
 <%- unless @sent.empty? -%>
 <h2 id='sent'>Sent</h2>
 <ul class='future'><%= render :partial => 'list', :locals => {:deadline_notifications => @sent} -%></ul>
-<p class="pagination"><%= paginate @sent %></p>
 <%- end -%>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,11 +1,11 @@
-<%# Link to the "Next" page
+<%# Link to the "First" page
   - available local variables
-    url:           url to the next page
+    url:           url to the first page
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote %>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, :remote => remote %>
 </span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,11 +1,8 @@
-<%# Link to the "Next" page
+<%# Non-link tag that stands for skipped pages...
   - available local variables
-    url:           url to the next page
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote %>
-</span>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,11 +1,11 @@
-<%# Link to the "Next" page
+<%# Link to the "Last" page
   - available local variables
-    url:           url to the next page
+    url:           url to the last page
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote %>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote %>
 </span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,5 @@
+<% if current_page.last? %>
+  <span class="csb" style="background-position:-96px 0;width:45px"></span>
+<% else %>
+  <%= link_to raw('<span class="csb ch" style="background-position:-96px 0;width:71px"></span><span style="display:block;margin-left:53px;text-decoration:underline">Next</span>'), url, :class => 'pn knavi', :id => 'pnnext', :style => 'text-align:left;text-decoration:none', :remote => remote %>
+<% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,5 @@
+<% if page.current? %>
+<td class="cur"><span class="csb" style="background-position:-53px 0;width:20px"></span><%= page %></td>
+<% else %>
+<td><%= link_to raw(%Q[<span class="csb ch" style="background-position:-74px 0;width:20px"></span>#{page}]), url, :class => 'fl', :remote => remote %></td>
+<% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,5 +1,12 @@
-<% if page.current? %>
-<td class="cur"><span class="csb" style="background-position:-53px 0;width:20px"></span><%= page %></td>
-<% else %>
-<td><%= link_to raw(%Q[<span class="csb ch" style="background-position:-74px 0;width:20px"></span>#{page}]), url, :class => 'fl', :remote => remote %></td>
-<% end %>
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,19 @@
+<style>
+#nav a{display:block}
+#nav td{padding:0;text-align:center}
+.cur {font-weight:bold}
+.csb {background:url(http://www.google.co.jp/images/srpr/nav_logo27.png) no-repeat;overflow:hidden;background-position:0 0;height:40px;display:block}
+#nav {font-family: arial,sans-serif; font-size:small}
+#nav a:link {text-decoration:none; color:#4496d3}
+#nav a:hover {text-decoration:underline}
+#nav a:active {color:#c11}
+#nav a:visited {color:#2200C1}
+.b {font-weight:bold}
+</style>
+<%= paginator.render do -%>
+<table id="nav" style="border-collapse:collapse;text-align:left;direction:ltr;margin:17px auto 0"><tbody><tr valign="top">
+<td class="b"><%= prev_page_tag -%></td>
+<% each_page.select(&:inside_window?).each do |page| %><%= page_tag page -%><% end %>
+<td class="b"><%= next_page_tag -%></td>
+</tr></tbody></table>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,19 +1,23 @@
-<style>
-#nav a{display:block}
-#nav td{padding:0;text-align:center}
-.cur {font-weight:bold}
-.csb {background:url(http://www.google.co.jp/images/srpr/nav_logo27.png) no-repeat;overflow:hidden;background-position:0 0;height:40px;display:block}
-#nav {font-family: arial,sans-serif; font-size:small}
-#nav a:link {text-decoration:none; color:#4496d3}
-#nav a:hover {text-decoration:underline}
-#nav a:active {color:#c11}
-#nav a:visited {color:#2200C1}
-.b {font-weight:bold}
-</style>
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
 <%= paginator.render do -%>
-<table id="nav" style="border-collapse:collapse;text-align:left;direction:ltr;margin:17px auto 0"><tbody><tr valign="top">
-<td class="b"><%= prev_page_tag -%></td>
-<% each_page.select(&:inside_window?).each do |page| %><%= page_tag page -%><% end %>
-<td class="b"><%= next_page_tag -%></td>
-</tr></tbody></table>
-<% end %>
+  <nav class="pagination">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <%= next_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,5 @@
+<% if current_page.first? %>
+  <span class="csb" style="background-position:-24px 0;width:28px"></span>
+<% else %>
+  <%= link_to raw('<span class="csb ch" style="background-position:0 0;float:right;width:53px"></span><span style="display:block;margin-right:35px;clear:right;text-decoration:underline">Previous</span>'), url, :class => 'pn knavi', :id => 'pnprev', :style => 'text-decoration:none', :remote => remote %>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,5 +1,11 @@
-<% if current_page.first? %>
-  <span class="csb" style="background-position:-24px 0;width:28px"></span>
-<% else %>
-  <%= link_to raw('<span class="csb ch" style="background-position:0 0;float:right;width:53px"></span><span style="display:block;margin-right:35px;clear:right;text-decoration:underline">Previous</span>'), url, :class => 'pn knavi', :id => 'pnprev', :style => 'text-decoration:none', :remote => remote %>
-<% end %>
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, :rel => 'prev', :remote => remote %>
+</span>

--- a/app/views/predictions/_list.html.erb
+++ b/app/views/predictions/_list.html.erb
@@ -5,6 +5,7 @@
 <%- end -%>
 
 <h2><%= title || 'Predictions' %></h2>
+<%= paginate @predictions %>
 
 <div class="popular">
   <%- if not @predictions.empty? -%>

--- a/app/views/predictions/_list.html.erb
+++ b/app/views/predictions/_list.html.erb
@@ -5,7 +5,6 @@
 <%- end -%>
 
 <h2><%= title || 'Predictions' %></h2>
-<%= paginate @predictions %>
 
 <div class="popular">
   <%- if not @predictions.empty? -%>
@@ -19,3 +18,7 @@
   </p>
   <%- end %>
 </div>
+
+<%- unless current_page?('/') %>
+<p class="pagination"><%= paginate @predictions %></p>
+<%- end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,3 +12,5 @@
 <% else %>
   <h2>No user found.</h2>
 <% end %>
+
+<p class="pagination"><%= paginate @predictions %></p>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,10 @@
+Kaminari.configure do |config|
+  config.default_per_page = 5
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,5 +1,5 @@
 Kaminari.configure do |config|
-  config.default_per_page = 5
+  config.default_per_page = 50
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ PredictionBook::Application.routes.draw do
   get '/predictions(/page/:page)' => 'predictions#index', :as => :predictions, :page => 1
   get '/predictions/unjudged(/page/:page)' => 'predictions#unjudged', :as => :unjudged, :page => 1
   get '/predictions/judged(/page/:page)' => 'predictions#judged', :as => :judged, :page => 1
+  get '/predictions/future(/page/:page)' => 'predictions#future', :as => :future, :page => 1
   get '/users/:id(/page/:page)' => 'users#show', :as => :users, :page => 1
 
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ PredictionBook::Application.routes.draw do
   resources :my_resources, :concerns => :paginatable
 
   get '/predictions(/page/:page)' => 'predictions#index', :as => :predictions, :page => 1
+  get '/predictions/unjudged(/page/:page)' => 'predictions#unjudged', :as => :unjudged, :page => 1
+  get '/predictions/judged(/page/:page)' => 'predictions#judged', :as => :judged, :page => 1
   get '/users/:id(/page/:page)' => 'users#show', :as => :users, :page => 1
 
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,13 @@
 PredictionBook::Application.routes.draw do
+
+  concern :paginatable do
+    get '(page/:page)', :action => :index, :on => :collection, :as => ''
+  end
+
+  resources :my_resources, :concerns => :paginatable
+
+  get '/predictions(/page/:page)' => 'predictions#index', :as => :predictions, :page => 1
+
   devise_for :users
 
   resources :users, only: [:show, :update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ PredictionBook::Application.routes.draw do
   resources :my_resources, :concerns => :paginatable
 
   get '/predictions(/page/:page)' => 'predictions#index', :as => :predictions, :page => 1
+  get '/users/:id(/page/:page)' => 'users#show', :as => :users, :page => 1
 
   devise_for :users
 


### PR DESCRIPTION
I chose Kaminari gem for pagination because:

- It has more stars and watchers on github
- Highest rated on ruby toolbox for pagination - https://www.ruby-toolbox.com/categories/pagination
- Comments on ruby toolbox stated it was better than will-paginate (2nd highest on ruby toolbox)
- It looked significantly more straight-forward to use than will-paginate (easy guides)

I have put in pagination wherever there was a reference to 100 items - 6 places (Users#show, Predictions#index, judged, unjudged, future). Some headings like "Recent predictions" and "Most recent predictions by (User)" may want to be changed as now they show all predictions (paginated).

I have set the number of items in the first page to 50. You can edit this easily in the  config/initializers/kaminari_config.rb file.

If you want to have pagination for email notifications, you will need to add to each section a show all page. This is because you can't have pagination for two sections on one page (if you go to the second page of one list, it will go to the second page of the other list as well).

The URLs for the pages are setup like this: /predictions/page/2, instead of /predictions?page=2. This looks prettier, but also allows for caching if you wanted to implement that on those pages.

Style of pagination - Kaminari themes provides various styles for pagination. I used the default style as other styles required frameworks (materialize, bootstrap etc and their associated css/js files). You can edit the look in .pagination class in the prediction.scss file.

The seed.rb file is outdated and cannot run (many validation errors). For future development, it would be good to fix this up. I had to manually create lots of records for testing.