### PR TITLE
Leave more room for user's name on navigation menu

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
 	        <li><%= link_to 'Login', new_user_session_path %></li>
 	        <li><%= link_to 'Signup', new_user_registration_path %></li>
 	  		<%- else -%>
-	  		  <li>Hello, <%= show_user(current_user)  %></li>
+	  		  <li><%= show_user(current_user)  %></li>
 	  		  <li><%= link_to 'Settings', settings_user_path(current_user) %></li>
 	  		  <li><%= link_to 'Logout', destroy_user_session_path, method: 'delete' %></li>
 	  		<%- end -%>

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -11,7 +11,7 @@ feature 'authentication' do
     fill_in 'user_login', with: 'login'
     fill_in 'user_password', with: 'password'
     click_button 'Log in'
-    expect(page).to have_content 'Hello, Bob'
+    expect(page).to have_content 'Bob'
     within 'ul#user-links' do
       click_link 'Logout'
     end


### PR DESCRIPTION
This is a quick-fix for [this](https://github.com/tricycle/predictionbook/issues/111) issue.