### PR TITLE
Introduce private groups

### DIFF
--- a/API.md
+++ b/API.md
@@ -22,7 +22,7 @@ api_token                     | string  | A token that identifies a unique user
 prediction[description]       | string  | Your prediction statement
 prediction[deadline]          | date    | when it will/won't have happened
 prediction[initial_confidence]| integer | A probability assignment
-prediction[visibility]        | integer | 0 Public, 1 Private (optional, default public)
+prediction[visibility]        | string  | visible_to_everyone (default), visible_to_creator
 
 PUT http://predictionbook.com/api/predictions/:id
 
@@ -31,4 +31,4 @@ Parameter name                | Value   | Description
 api_token                     | string  | A token that identifies a unique user
 prediction[description]       | string  | Your prediction statement
 prediction[deadline]          | date    | When it will/won't have happened
-prediction[visibility]        | integer | 0 Public, 1 Private (optional, default public)
+prediction[visibility]        | string  | visible_to_everyone (default), visible_to_creator

--- a/API.md
+++ b/API.md
@@ -22,7 +22,7 @@ api_token                     | string  | A token that identifies a unique user
 prediction[description]       | string  | Your prediction statement
 prediction[deadline]          | date    | when it will/won't have happened
 prediction[initial_confidence]| integer | A probability assignment
-prediction[private]           | boolean | True if you want it to be private (optional)
+prediction[visibility]        | integer | 0 Public, 1 Private (optional, default public)
 
 PUT http://predictionbook.com/api/predictions/:id
 
@@ -31,4 +31,4 @@ Parameter name                | Value   | Description
 api_token                     | string  | A token that identifies a unique user
 prediction[description]       | string  | Your prediction statement
 prediction[deadline]          | date    | When it will/won't have happened
-prediction[private]           | boolean | True if you want it to be private (optional)
+prediction[visibility]        | integer | 0 Public, 1 Private (optional, default public)

--- a/app/controllers/api/prediction_judgements_controller.rb
+++ b/app/controllers/api/prediction_judgements_controller.rb
@@ -2,7 +2,7 @@ module Api
   class PredictionJudgementsController < AuthorisedController
     def create
       @prediction = Prediction.find(params[:prediction_id])
-      raise UnauthorizedRequest unless @user.authorized_for(@prediction)
+      raise UnauthorizedRequest unless @user.authorized_for(@groups, @prediction)
       @prediction.judge!(params[:outcome], @user)
       render status: :created, json: @prediction.judgements.last
     end

--- a/app/controllers/api/predictions_controller.rb
+++ b/app/controllers/api/predictions_controller.rb
@@ -46,11 +46,8 @@ module Api
 
     def build_new_prediction
       permitted_params = prediction_params
-      if permitted_params[:visibility].nil? && @user.present?
-        permitted_params[:visibility] = @user.visibility_default
-      end
-
-      @prediction = Prediction.new(prediction_params.merge(creator: @user))
+      permitted_params[:visibility] ||= @user.try(:visibility_default)
+      @prediction = Prediction.new(permitted_params.merge(creator: @user))
     end
 
     def build_predictions

--- a/app/controllers/api/predictions_controller.rb
+++ b/app/controllers/api/predictions_controller.rb
@@ -36,11 +36,12 @@ module Api
     private
 
     def authorize_to_see_prediction
-      raise UnauthorizedRequest unless @prediction.visible_to_everyone? || @user.authorized_for(@prediction)
+      raise UnauthorizedRequest unless @prediction.visible_to_everyone? ||
+                                       @user.authorized_for(@groups, @prediction)
     end
 
     def authorize_to_update_prediction
-      raise UnauthorizedRequest unless @user.authorized_for(@prediction)
+      raise UnauthorizedRequest unless @user.authorized_for(@groups, @prediction)
     end
 
     def build_new_prediction

--- a/app/controllers/api/predictions_controller.rb
+++ b/app/controllers/api/predictions_controller.rb
@@ -36,7 +36,7 @@ module Api
     private
 
     def authorize_to_see_prediction
-      raise UnauthorizedRequest unless @prediction.public? || @user.authorized_for(@prediction)
+      raise UnauthorizedRequest unless @prediction.visible_to_everyone? || @user.authorized_for(@prediction)
     end
 
     def authorize_to_update_prediction
@@ -44,8 +44,9 @@ module Api
     end
 
     def build_new_prediction
-      unless prediction_params[:private] && @user
-        prediction_params[:private] = @user.private_default
+      visible_to_creator = Visibility::VALUES[:visible_to_creator]
+      unless prediction_params[:visibility] == visible_to_creator && @user.present?
+        prediction_params[:visibility] = @user.visibility_default
       end
 
       @prediction = Prediction.new(prediction_params.merge(creator: @user))

--- a/app/controllers/api/predictions_controller.rb
+++ b/app/controllers/api/predictions_controller.rb
@@ -65,6 +65,7 @@ module Api
 
     def prediction_params
       permitted_params = params.require(:prediction).permit!
+      # Handle previous version of the API that uses a private flag instead of visibility
       if permitted_params[:private].present?
         private_value = permitted_params.delete(:private)
         permitted_params[:visibility] = 'visible_to_creator' if private_value

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
 
   helper :all # include all helpers, all the time
 
-  before_action :set_timezone, :clear_return_to, :login_via_token
+  before_action :set_timezone, :clear_return_to, :login_via_token, :assign_groups
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :force_change_password
 
@@ -47,6 +47,14 @@ class ApplicationController < ActionController::Base
     user_timezone = current_user.try(:timezone)
     Time.zone = user_timezone.blank? ? 'UTC' : user_timezone
     Chronic.time_class = Time.zone
+  end
+
+  def assign_groups
+    @groups = if current_user.nil?
+                []
+              else
+                Group.all.select { |group| group.user_is_a_member?(current_user) }
+              end
   end
 
   def clear_return_to

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,8 +6,8 @@ class GroupsController < ApplicationController
   end
 
   def show
-    @group = Group.find(params[:id])
-    raise ActionController::RoutingError, 'Not Found' unless @groups.include?(@group)
+    @group = @groups.find { |group| group.id == params[:id] }
+    raise ActionController::RoutingError, 'Not Found' if @group.nil?
     @predictions = Prediction.where(group: @group).page(params[:page])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,13 @@
+class GroupsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    raise ActionController::RoutingError, 'Not Found' if @groups.blank?
+  end
+
+  def show
+    @group = Group.find(params[:id])
+    @predictions = Prediction.where('1 = 0').page(1)
+    raise ActionController::RoutingError, 'Not Found' unless @groups.include?(@group)
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,7 +7,7 @@ class GroupsController < ApplicationController
 
   def show
     @group = Group.find(params[:id])
-    @predictions = Prediction.where('1 = 0').page(1)
     raise ActionController::RoutingError, 'Not Found' unless @groups.include?(@group)
+    @predictions = Prediction.where(group: @group).page(params[:page])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,7 +6,7 @@ class GroupsController < ApplicationController
   end
 
   def show
-    @group = @groups.find { |group| group.id == params[:id] }
+    @group = @groups.find { |group| group.id == params[:id].to_i }
     raise ActionController::RoutingError, 'Not Found' if @group.nil?
     @predictions = Prediction.where(group: @group).page(params[:page])
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
     @title       = "Most recent predictions by #{@user}"
     @predictions = @user.predictions
     @statistics  = @user.statistics
-    @predictions = @predictions.not_private unless user_is_current_user?
+    @predictions = @predictions.visible_to_everyone unless user_is_current_user?
     @predictions = @predictions.page(params[:page])
   end
 
@@ -94,6 +94,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:login, :email, :name, :timezone, :private_default, :api_token)
+    params.require(:user).permit(:login, :email, :name, :timezone, :visibility_default, :api_token)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -77,7 +77,7 @@ class UsersController < ApplicationController
   end
 
   def user_must_be_current_user
-    render status: :forbidden unless user_is_current_user?
+    head :forbidden unless user_is_current_user?
   end
 
   private
@@ -94,6 +94,14 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:login, :email, :name, :timezone, :visibility_default, :api_token)
+    permitted_params = params.require(:user).permit(:login, :email, :name, :timezone,
+                                                    :visibility_default, :api_token)
+    visibility_default = permitted_params[:visibility_default]
+    if visibility_default.present?
+      attributes = Visibility.option_to_attributes(visibility_default)
+      permitted_params[:visibility_default] = attributes[:visibility]
+      permitted_params[:group_default_id] = attributes[:group_id]
+    end
+    permitted_params
   end
 end

--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -19,8 +19,8 @@ module VersionHelper
       "changed their prediction from “#{TitleTagPresenter.new(old_value).tag}”"
     when :withdrawn then
       "#{new_value ? 'withdrew' : 'republished'} the prediction"
-    when :private then
-      "made the prediction #{new_value ? 'private' : 'public'}"
+    when :visibility then
+      "made the prediction #{Visibility::VALUES.key(new_value).to_s.humanize.downcase}"
     end
   end
 end

--- a/app/models/base_statistics.rb
+++ b/app/models/base_statistics.rb
@@ -50,7 +50,7 @@ class BaseStatistics
     axis_labels = '1:|Confidence  (%)|3:|Accuracy'
     axis_labels_positions = '1,50|3,50'
 
-    'http://chart.apis.google.com/chart?' + [
+    'https://chart.apis.google.com/chart?' + [
       'cht=s', # scatterplot
       "chg=#{grid_lines}",
       "chds=#{data_ranges}",

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,9 @@ class Group < ActiveRecord::Base
   validates :email_domains, format: {
     with: /\A(([a-z]+[a-z\.]+[\.]+[a-z]+),)*([a-z]+[a-z\.]+[\.]+[a-z]+)\z/, allow_nil: true
   }
+
+  def user_is_a_member?(user)
+    domain = Mail::Address.new(user.email).domain
+    (email_domains || '').split(',').include?(domain)
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,6 @@
+class Group < ActiveRecord::Base
+  validates :name, presence: true, uniqueness: true
+  validates :email_domains, format: {
+    with: /\A(([a-z]+[a-z\.]+[\.]+[a-z]+),)*([a-z]+[a-z\.]+[\.]+[a-z]+)\z/, allow_nil: true
+  }
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
+  # Regex validates comma-delimited list of valid email domains with no spaces
   validates :email_domains, format: {
     with: /\A(([a-z]+[a-z\.]+[\.]+[a-z]+),)*([a-z]+[a-z\.]+[\.]+[a-z]+)\z/, allow_nil: true
   }

--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -1,6 +1,8 @@
 class Prediction < ActiveRecord::Base
   has_many :versions, autosave: true, class_name: PredictionVersion
 
+  belongs_to :group
+
   enum visibility: Visibility::VALUES
 
   before_save :create_version_if_required

--- a/app/models/prediction_version.rb
+++ b/app/models/prediction_version.rb
@@ -1,6 +1,8 @@
 class PredictionVersion < ActiveRecord::Base
   belongs_to :prediction
 
+  enum visibility: Visibility::VALUES
+
   def self.create_from_current_prediction_if_required(prediction)
     return unless new_version_required?(prediction)
     new_version = prediction.versions.build
@@ -13,7 +15,7 @@ class PredictionVersion < ActiveRecord::Base
   end
 
   def self.versioned_prediction_columns
-    [:description, :deadline, :withdrawn, :private]
+    %i[description deadline withdrawn visibility]
   end
 
   def self.new_version_required?(prediction)

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -22,10 +22,10 @@ class Response < ActiveRecord::Base
   WAGER_CONDITION = 'confidence is not null'.freeze
   scope :wagers, -> { where(WAGER_CONDITION) }
 
-  scope :not_private, -> { joins(:prediction).where(predictions: { private: false }) }
+  scope :visible_to_everyone, -> { where(prediction: Prediction.visible_to_everyone) }
 
   def self.recent(limit: 100)
-    order(created_at: :desc).not_private.prefetch_joins.limit(limit)
+    order(created_at: :desc).visible_to_everyone.prefetch_joins.limit(limit)
   end
 
   def self.prefetch_joins

--- a/app/models/statistics.rb
+++ b/app/models/statistics.rb
@@ -84,7 +84,7 @@ class Statistics < BaseStatistics
     axis_labels = '1:|Confidence  (%)|3:|Accuracy'
     axis_labels_positions = '1,50|3,50'
 
-    'http://chart.apis.google.com/chart?' + [
+    'https://chart.apis.google.com/chart?' + [
       'cht=s', # scatterplot
       "chg=#{grid_lines}",
       "chds=#{data_ranges}",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,13 +80,12 @@ class User < ActiveRecord::Base
     !!predictions.index(&:due_for_judgement?)
   end
 
-  def authorized_for(prediction, action = 'show')
+  def authorized_for(user_groups, prediction, action = 'show')
     is_creator = self == prediction.creator
-    if %w[index show].include?(action)
-      prediction.visible_to_everyone? || (is_creator && prediction.visible_to_creator?) || admin?
-    else
-      is_creator
-    end
+    return true if is_creator || admin?
+    return false unless %w[index show].include?(action)
+    prediction.visible_to_everyone? ||
+      (prediction.visible_to_group? && user_groups.include?(prediction.group))
   end
 
   def admin?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ActiveRecord::Base
 
   nillify_blank :email, :name
 
+  enum visibility_default: Visibility::VALUES
+
   delegate :image_url, to: :statistics, prefix: true
 
   validates :login, presence: true, length: { maximum: 255 }, uniqueness: { case_sensitive: false },
@@ -71,16 +73,20 @@ class User < ActiveRecord::Base
   end
 
   def has_email?
-    !email.blank?
+    email.present?
   end
 
   def has_overdue_judgements?
     !!predictions.index(&:due_for_judgement?)
   end
 
-  def authorized_for(prediction)
+  def authorized_for(prediction, action = 'show')
     is_creator = self == prediction.creator
-    is_creator || (!prediction.private? && admin?)
+    if %w[index show].include?(action)
+      prediction.visible_to_everyone? || (is_creator && prediction.visible_to_creator?) || admin?
+    else
+      is_creator
+    end
   end
 
   def admin?

--- a/app/models/visibility.rb
+++ b/app/models/visibility.rb
@@ -1,11 +1,29 @@
 module Visibility
-  VALUES = { visible_to_everyone: 0, visible_to_creator: 1 }.freeze
+  VALUES = { visible_to_everyone: 0, visible_to_creator: 1, visible_to_group: 2 }.freeze
 
-  def self.select_options_html(value)
-    VALUES.keys.map do |key|
+  def self.select_options_html(groups, current_visibility, current_group_id)
+    non_group_options = (VALUES.keys - [:visible_to_group]).map do |key|
       key_string = key.to_s
       label = key_string.humanize
-      "<option value=\"#{key}\" #{value == key_string ? 'selected' : ''}>#{label}</option>"
+      "<option value=\"#{key}\" #{current_visibility == key_string ? 'selected' : ''}>#{label}</option>"
     end.join
+
+    group_options = groups.map do |group|
+      group_id = group.id
+      key = "visible_to_group_#{group_id}"
+      label = "Visible to #{group.name} group"
+      selected = current_visibility == 'visible_to_group' && current_group_id == group_id
+      "<option value=\"#{key}\" #{selected ? 'selected' : ''}>#{label}</option>"
+    end.join
+
+    non_group_options + group_options
+  end
+
+  def self.option_to_attributes(option)
+    if option.starts_with?('visible_to_group_')
+      { visibility: 'visible_to_group', group_id: option.gsub('visible_to_group_', '').to_i }
+    else
+      { visibility: option, group_id: nil }
+    end
   end
 end

--- a/app/models/visibility.rb
+++ b/app/models/visibility.rb
@@ -1,3 +1,11 @@
 module Visibility
   VALUES = { visible_to_everyone: 0, visible_to_creator: 1 }.freeze
+
+  def self.select_options_html(value)
+    VALUES.keys.map do |key|
+      key_string = key.to_s
+      label = key_string.humanize
+      "<option value=\"#{key}\" #{value == key_string ? 'selected' : ''}>#{label}</option>"
+    end.join
+  end
 end

--- a/app/models/visibility.rb
+++ b/app/models/visibility.rb
@@ -1,0 +1,3 @@
+module Visibility
+  VALUES = { visible_to_everyone: 0, visible_to_creator: 1 }.freeze
+end

--- a/app/views/groups/_group.html.erb
+++ b/app/views/groups/_group.html.erb
@@ -1,0 +1,5 @@
+<li class="group">
+  <p>
+     <span class='title'><%= link_to TitleTagPresenter.new(group.name).tag, group %></span>
+  </p>
+</li>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,0 +1,7 @@
+<h2>My groups</h2>
+
+<div class="popular">
+  <ul>
+    <%= render :partial => @groups  %>
+  </ul>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'predictions/list', locals: { title: "#{@group.name} group predictions" } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
 	<div id="header" class="wrapper clear">
 		<div id="main_nav" class="clear">
 			<ul id="nav-menu">
-			  <li><%= link_to 'Make a Prediction', new_prediction_path %></li>
+			  <li><%= link_to 'New prediction', new_prediction_path %></li>
         <li><%= link_to 'View predictions', predictions_path %></li>
 			  <li><%= link_to 'Happenstance', happenstance_path %></li>
         <li><%= link_to 'Upcoming predictions', future_predictions_path %></li>
@@ -46,6 +46,9 @@
 	        <li><%= link_to 'Signup', new_user_registration_path %></li>
 	  		<%- else -%>
 	  		  <li>Hello, <%= show_user(current_user)  %></li>
+					<%- if @groups.present? -%>
+						<li><%= link_to 'Groups', groups_path %></li>
+					<% end %>
 	  		  <li><%= link_to 'Settings', settings_user_path(current_user) %></li>
 	  		  <li><%= link_to 'Logout', destroy_user_session_path, method: 'delete' %></li>
 	  		<%- end -%>

--- a/app/views/predictions/_form.html.erb
+++ b/app/views/predictions/_form.html.erb
@@ -5,13 +5,13 @@
     <%= f.text_area :description, :label => 'What do you think will (or won\'t) happen?' %>
     <%= f.confidence_field :initial_confidence, :label => 'What\'s your estimate of this happening?' %>
     <%= f.text_field :deadline_text, :label => 'When will you know?', :trailing_content => link_to('Help', '#date-help', :class => 'help facebox'), :preview => true %>
-    <%= f.submit 'Lock it in!' %>
     <%= f.check_box :notify_creator, :label => 'Email me when I should know the outcome' %>
     <%- unless !current_user.present? || current_user.has_email? -%>
     <p>(Email will not be sent until you <%= link_to "set your email", settings_user_path(current_user) %>)</p>
     <%- end -%>
-    <%= f.check_box :private, :label => 'Keep this prediction private.' %>
+    <%= f.select_field :visibility, raw(Visibility::VALUES.map { |key_value_pair| "<option value=\"#{key_value_pair.first}\" #{@prediction.visibility == key_value_pair.first.to_s ? "selected" : ''}>#{key_value_pair.first.to_s.humanize}</option>" }.join), label: 'Visibility' %>
     <p class='note'><%= render :partial => 'private_note' %></p>
+    <%= f.submit 'Lock it in!' %>
   </div>
 <% end %>
 

--- a/app/views/predictions/_form.html.erb
+++ b/app/views/predictions/_form.html.erb
@@ -9,7 +9,7 @@
     <%- unless !current_user.present? || current_user.has_email? -%>
     <p>(Email will not be sent until you <%= link_to "set your email", settings_user_path(current_user) %>)</p>
     <%- end -%>
-    <%= f.select_field :visibility, raw(Visibility.select_options_html(@prediction.visibility)), label: 'Visibility' %>
+    <%= f.select_field :visibility, raw(Visibility.select_options_html(@groups, @prediction.visibility, @prediction.group_id)), label: 'Visibility' %>
     <p class='note'><%= render :partial => 'private_note' %></p>
     <%= f.submit 'Lock it in!' %>
   </div>

--- a/app/views/predictions/_form.html.erb
+++ b/app/views/predictions/_form.html.erb
@@ -9,7 +9,7 @@
     <%- unless !current_user.present? || current_user.has_email? -%>
     <p>(Email will not be sent until you <%= link_to "set your email", settings_user_path(current_user) %>)</p>
     <%- end -%>
-    <%= f.select_field :visibility, raw(Visibility::VALUES.map { |key_value_pair| "<option value=\"#{key_value_pair.first}\" #{@prediction.visibility == key_value_pair.first.to_s ? "selected" : ''}>#{key_value_pair.first.to_s.humanize}</option>" }.join), label: 'Visibility' %>
+    <%= f.select_field :visibility, raw(Visibility.select_options_html(@prediction.visibility)), label: 'Visibility' %>
     <p class='note'><%= render :partial => 'private_note' %></p>
     <%= f.submit 'Lock it in!' %>
   </div>

--- a/app/views/predictions/_prediction.html.erb
+++ b/app/views/predictions/_prediction.html.erb
@@ -1,6 +1,7 @@
  <li class="prediction <%= prediction.readable_outcome %>">
    <p>
       <%- if prediction.visible_to_creator? -%><span class='status private'>[private]</span><%- end -%>
+      <%- if prediction.visible_to_group? -%><span class='status private'>[<%= link_to prediction.group.name, group_path(prediction.group) %>]</span><%- end -%>
       <%= render :partial => 'predictions/simple', :locals => {:prediction => prediction} %>
    </p>
    <p class='description'>

--- a/app/views/predictions/_prediction.html.erb
+++ b/app/views/predictions/_prediction.html.erb
@@ -1,6 +1,6 @@
  <li class="prediction <%= prediction.readable_outcome %>">
    <p>
-      <%- if prediction.private? -%><span class='status private'>[private]</span><%- end -%>
+      <%- if prediction.visible_to_creator? -%><span class='status private'>[private]</span><%- end -%>
       <%= render :partial => 'predictions/simple', :locals => {:prediction => prediction} %>
    </p>
    <p class='description'>

--- a/app/views/predictions/_private_note.html.erb
+++ b/app/views/predictions/_private_note.html.erb
@@ -1,3 +1,3 @@
-Private predictions will only show up on
+Predictions visible to the prediction creator will only show up on
 <%= link_to 'your user page', user_path(current_user) %>,
 and only when you are logged in.

--- a/app/views/predictions/edit.html.erb
+++ b/app/views/predictions/edit.html.erb
@@ -3,7 +3,7 @@
   <h2>Edit this Prediction</h2>
   <%= f.text_area :description, :label => 'What do you think will happen?' %>
   <%= f.text_field :deadline_text, :label => 'When you will know?', :preview => true %>
-  <%= f.select_field :visibility, raw(Visibility::VALUES.keys.map { |key| "<option value=\"#{key}\">#{key.to_s.humanize}</option>" }.join), label: 'Visibility' %>
+  <%= f.select_field :visibility, raw(Visibility.select_options_html(@prediction.visibility)), label: 'Visibility' %>
   <p class='note'><%= render :partial => 'private_note' %></p>
   <%= f.submit 'Save changes' %>
 </div>

--- a/app/views/predictions/edit.html.erb
+++ b/app/views/predictions/edit.html.erb
@@ -3,7 +3,7 @@
   <h2>Edit this Prediction</h2>
   <%= f.text_area :description, :label => 'What do you think will happen?' %>
   <%= f.text_field :deadline_text, :label => 'When you will know?', :preview => true %>
-  <%= f.select_field :visibility, raw(Visibility.select_options_html(@prediction.visibility)), label: 'Visibility' %>
+  <%= f.select_field :visibility, raw(Visibility.select_options_html(@groups, @prediction.visibility, @prediction.group_id)), label: 'Visibility' %>
   <p class='note'><%= render :partial => 'private_note' %></p>
   <%= f.submit 'Save changes' %>
 </div>

--- a/app/views/predictions/edit.html.erb
+++ b/app/views/predictions/edit.html.erb
@@ -3,8 +3,8 @@
   <h2>Edit this Prediction</h2>
   <%= f.text_area :description, :label => 'What do you think will happen?' %>
   <%= f.text_field :deadline_text, :label => 'When you will know?', :preview => true %>
-  <%= f.submit 'Save changes' %>
-  <%= f.check_box :private, :label => 'Keep this prediction private.' %>
+  <%= f.select_field :visibility, raw(Visibility::VALUES.keys.map { |key| "<option value=\"#{key}\">#{key.to_s.humanize}</option>" }.join), label: 'Visibility' %>
   <p class='note'><%= render :partial => 'private_note' %></p>
+  <%= f.submit 'Save changes' %>
 </div>
 <% end %>

--- a/app/views/predictions/show.html.erb
+++ b/app/views/predictions/show.html.erb
@@ -1,5 +1,5 @@
 <h1 class="<%= @prediction.readable_outcome %>">
-  <% if current_user && current_user.authorized_for(@prediction) %>
+  <% if current_user && current_user.authorized_for(@groups, @prediction) %>
     <%= link_to 'Edit', edit_prediction_path(@prediction), :class => 'edit' %>
   <% end %>
   <%= TitleTagPresenter.new(@prediction.description).tag %>
@@ -15,6 +15,11 @@
 <%- if @prediction.visible_to_creator? -%>
   <p class='note'>
     This prediction is <strong>private</strong>. <%= render :partial => 'predictions/private_note' %>
+  </p>
+<%- end -%>
+<%- if @prediction.visible_to_group? -%>
+  <p class='note'>
+    This prediction is only visible to members of the <strong><%= link_to @prediction.group.name, group_path(@prediction.group) %></strong> group.
   </p>
 <%- end -%>
 

--- a/app/views/predictions/show.html.erb
+++ b/app/views/predictions/show.html.erb
@@ -12,7 +12,7 @@
   <%= render :partial => @prediction.judgement %><% end -%>
 </p>
 
-<%- if @prediction.private? -%>
+<%- if @prediction.visible_to_creator? -%>
   <p class='note'>
     This prediction is <strong>private</strong>. <%= render :partial => 'predictions/private_note' %>
   </p>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -3,7 +3,7 @@
   <%= f.text_field :name %>
   <%= f.text_field :email %>
   <%= f.timezone_field :timezone %>
-  <%= f.select_field :visibility_default, raw(Visibility::VALUES.map { |key_value_pair| "<option value=\"#{key_value_pair.first}\" #{@user.visibility_default == key_value_pair.first.to_s ? "selected" : ''}>#{key_value_pair.first.to_s.humanize}</option>" }.join), label: 'By default, create predictions that are' %>
+  <%= f.select_field :visibility_default, raw(Visibility.select_options_html(@user.visibility_default)), label: 'By default, create predictions that are' %>
   <p class='note'><%= render :partial => 'predictions/private_note' %></p>
   <%= f.submit 'Change details' %>
 <% end -%>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -3,7 +3,7 @@
   <%= f.text_field :name %>
   <%= f.text_field :email %>
   <%= f.timezone_field :timezone %>
-  <%= f.select_field :visibility_default, raw(Visibility.select_options_html(@user.visibility_default)), label: 'By default, create predictions that are' %>
+  <%= f.select_field :visibility_default, raw(Visibility.select_options_html(@groups, @user.visibility_default, @user.group_default_id)), label: 'By default, create predictions that are' %>
   <p class='note'><%= render :partial => 'predictions/private_note' %></p>
   <%= f.submit 'Change details' %>
 <% end -%>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -3,7 +3,7 @@
   <%= f.text_field :name %>
   <%= f.text_field :email %>
   <%= f.timezone_field :timezone %>
-  <%= f.check_box :private_default, :label => 'Keep my predictions private by default' %>
+  <%= f.select_field :visibility_default, raw(Visibility::VALUES.map { |key_value_pair| "<option value=\"#{key_value_pair.first}\" #{@user.visibility_default == key_value_pair.first.to_s ? "selected" : ''}>#{key_value_pair.first.to_s.humanize}</option>" }.join), label: 'By default, create predictions that are' %>
   <p class='note'><%= render :partial => 'predictions/private_note' %></p>
   <%= f.submit 'Change details' %>
 <% end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ PredictionBook::Application.routes.draw do
     resources :deadline_notifications
   end
 
+  resources :groups, only: [:index, :show]
+
   resources :deadline_notifications
   resources :response_notifications
 

--- a/db/migrate/20170411233947_add_visibility_to_predictions.rb
+++ b/db/migrate/20170411233947_add_visibility_to_predictions.rb
@@ -1,0 +1,5 @@
+class AddVisibilityToPredictions < ActiveRecord::Migration
+  def change
+    add_column :predictions, :visibility, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20170412000117_convert_private_flag_to_visibility_in_predictions.rb
+++ b/db/migrate/20170412000117_convert_private_flag_to_visibility_in_predictions.rb
@@ -1,0 +1,19 @@
+class ConvertPrivateFlagToVisibilityInPredictions < ActiveRecord::Migration
+  def up
+    sql = <<-EOS
+    UPDATE predictions
+    SET visibility = 1
+    WHERE private = true
+    EOS
+    ActiveRecord::Base.connection.execute sql
+  end
+
+  def down
+    sql = <<-EOS
+    UPDATE predictions
+    SET private = true
+    WHERE visibility = 1
+    EOS
+    ActiveRecord::Base.connection.execute sql
+  end
+end

--- a/db/migrate/20170412000300_drop_private_flag_from_predictions.rb
+++ b/db/migrate/20170412000300_drop_private_flag_from_predictions.rb
@@ -1,0 +1,5 @@
+class DropPrivateFlagFromPredictions < ActiveRecord::Migration
+  def change
+    remove_column :predictions, :private, :boolean, default: false
+  end
+end

--- a/db/migrate/20170412000734_add_visibility_to_prediction_versions.rb
+++ b/db/migrate/20170412000734_add_visibility_to_prediction_versions.rb
@@ -1,0 +1,5 @@
+class AddVisibilityToPredictionVersions < ActiveRecord::Migration
+  def change
+    add_column :prediction_versions, :visibility, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20170412000809_convert_private_flag_to_visibility_in_prediction_versions.rb
+++ b/db/migrate/20170412000809_convert_private_flag_to_visibility_in_prediction_versions.rb
@@ -1,0 +1,19 @@
+class ConvertPrivateFlagToVisibilityInPredictionVersions < ActiveRecord::Migration
+  def up
+    sql = <<-EOS
+    UPDATE prediction_versions
+    SET visibility = 1
+    WHERE private = true
+    EOS
+    ActiveRecord::Base.connection.execute sql
+  end
+
+  def down
+    sql = <<-EOS
+    UPDATE prediction_versions
+    SET private = true
+    WHERE visibility = 1
+    EOS
+    ActiveRecord::Base.connection.execute sql
+  end
+end

--- a/db/migrate/20170412000845_drop_private_flag_from_prediction_versions.rb
+++ b/db/migrate/20170412000845_drop_private_flag_from_prediction_versions.rb
@@ -1,0 +1,5 @@
+class DropPrivateFlagFromPredictionVersions < ActiveRecord::Migration
+  def change
+    remove_column :prediction_versions, :private, :boolean, default: false
+  end
+end

--- a/db/migrate/20170412021804_add_visibility_default_to_users.rb
+++ b/db/migrate/20170412021804_add_visibility_default_to_users.rb
@@ -1,0 +1,5 @@
+class AddVisibilityDefaultToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :visibility_default, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20170412022106_convert_private_default_flag_to_visibility_default_in_users.rb
+++ b/db/migrate/20170412022106_convert_private_default_flag_to_visibility_default_in_users.rb
@@ -1,0 +1,20 @@
+class ConvertPrivateDefaultFlagToVisibilityDefaultInUsers < ActiveRecord::Migration
+  def up
+    sql = <<-EOS
+    UPDATE users
+    SET visibility_default = 1
+    WHERE private_default = true
+    EOS
+    ActiveRecord::Base.connection.execute sql
+  end
+
+  def down
+    sql = <<-EOS
+    UPDATE users
+    SET private_default = true
+    WHERE visibility_default = 1
+    EOS
+    ActiveRecord::Base.connection.execute sql
+  end
+
+end

--- a/db/migrate/20170412022200_drop_private_default_flag_from_users.rb
+++ b/db/migrate/20170412022200_drop_private_default_flag_from_users.rb
@@ -1,0 +1,5 @@
+class DropPrivateDefaultFlagFromUsers < ActiveRecord::Migration
+  def change
+    remove_column :users, :private_default, :boolean, default: false
+  end
+end

--- a/db/migrate/20170412071152_create_groups.rb
+++ b/db/migrate/20170412071152_create_groups.rb
@@ -1,0 +1,10 @@
+class CreateGroups < ActiveRecord::Migration
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.string :email_domains, null: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20170412121143_add_group_to_predictions.rb
+++ b/db/migrate/20170412121143_add_group_to_predictions.rb
@@ -1,0 +1,5 @@
+class AddGroupToPredictions < ActiveRecord::Migration
+  def change
+    add_reference :predictions, :group, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20170412121536_add_group_default_to_users.rb
+++ b/db/migrate/20170412121536_add_group_default_to_users.rb
@@ -1,0 +1,6 @@
+class AddGroupDefaultToUsers < ActiveRecord::Migration
+  def change
+    add_reference :users, :group_default, index: true
+    add_foreign_key :users, :groups, column: :group_default_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170412071152) do
+ActiveRecord::Schema.define(version: 20170412121536) do
 
   create_table "credence_answers", force: :cascade do |t|
     t.integer  "credence_question_id", limit: 4
@@ -124,9 +124,11 @@ ActiveRecord::Schema.define(version: 20170412071152) do
     t.boolean  "withdrawn",               default: false
     t.integer  "version",     limit: 4,   default: 1
     t.integer  "visibility",  limit: 4,   default: 0,     null: false
+    t.integer  "group_id",    limit: 4
   end
 
   add_index "predictions", ["creator_id"], name: "index_predictions_on_creator_id", using: :btree
+  add_index "predictions", ["group_id"], name: "index_predictions_on_group_id", using: :btree
   add_index "predictions", ["uuid"], name: "index_predictions_on_uuid", unique: true, using: :btree
 
   create_table "responses", force: :cascade do |t|
@@ -164,10 +166,12 @@ ActiveRecord::Schema.define(version: 20170412071152) do
     t.string   "current_sign_in_ip",        limit: 255
     t.string   "last_sign_in_ip",           limit: 255
     t.integer  "visibility_default",        limit: 4,   default: 0,     null: false
+    t.integer  "group_default_id",          limit: 4
   end
 
   add_index "users", ["api_token"], name: "index_users_on_api_token", using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["group_default_id"], name: "index_users_on_group_default_id", using: :btree
   add_index "users", ["login"], name: "index_users_on_login", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
@@ -179,4 +183,6 @@ ActiveRecord::Schema.define(version: 20170412071152) do
     t.datetime "updated_at"
   end
 
+  add_foreign_key "predictions", "groups"
+  add_foreign_key "users", "groups", column: "group_default_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160511055641) do
+ActiveRecord::Schema.define(version: 20170412022200) do
 
   create_table "credence_answers", force: :cascade do |t|
     t.integer  "credence_question_id", limit: 4
@@ -102,9 +102,9 @@ ActiveRecord::Schema.define(version: 20160511055641) do
     t.integer  "creator_id",    limit: 4
     t.string   "uuid",          limit: 255
     t.boolean  "withdrawn",                 default: false
-    t.boolean  "private",                   default: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "visibility",    limit: 4,   default: 0,     null: false
   end
 
   create_table "predictions", force: :cascade do |t|
@@ -115,8 +115,8 @@ ActiveRecord::Schema.define(version: 20160511055641) do
     t.integer  "creator_id",  limit: 4
     t.string   "uuid",        limit: 255
     t.boolean  "withdrawn",               default: false
-    t.boolean  "private",                 default: false
     t.integer  "version",     limit: 4,   default: 1
+    t.integer  "visibility",  limit: 4,   default: 0,     null: false
   end
 
   add_index "predictions", ["creator_id"], name: "index_predictions_on_creator_id", using: :btree
@@ -145,7 +145,6 @@ ActiveRecord::Schema.define(version: 20160511055641) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "timezone",                  limit: 255
-    t.boolean  "private_default",                       default: false
     t.boolean  "admin",                                 default: false, null: false
     t.string   "api_token",                 limit: 255
     t.string   "encrypted_password",        limit: 255, default: "",    null: false
@@ -157,6 +156,7 @@ ActiveRecord::Schema.define(version: 20160511055641) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip",        limit: 255
     t.string   "last_sign_in_ip",           limit: 255
+    t.integer  "visibility_default",        limit: 4,   default: 0,     null: false
   end
 
   add_index "users", ["api_token"], name: "index_users_on_api_token", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170412022200) do
+ActiveRecord::Schema.define(version: 20170412071152) do
 
   create_table "credence_answers", force: :cascade do |t|
     t.integer  "credence_question_id", limit: 4
@@ -66,6 +66,13 @@ ActiveRecord::Schema.define(version: 20170412022200) do
   end
 
   add_index "credence_questions", ["text_id"], name: "index_credence_questions_on_text_id", unique: true, using: :btree
+
+  create_table "groups", force: :cascade do |t|
+    t.string   "name",          limit: 255, null: false
+    t.string   "email_domains", limit: 255
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
 
   create_table "judgements", force: :cascade do |t|
     t.integer  "prediction_id", limit: 4

--- a/lib/labelled_form_builder.rb
+++ b/lib/labelled_form_builder.rb
@@ -1,4 +1,11 @@
 class LabelledFormBuilder < ActionView::Helpers::FormBuilder
+  def select_field(method, html_options, options = {})
+    options = add_input_class(options)
+    labelling_surround(method, options) do |sub_method, sub_options|
+      select(sub_method, html_options, sub_options)
+    end
+  end
+
   def check_box(method, options = {})
     labelling_surround(method, options.merge(label_containing: true)) do |sub_method, sub_options|
       super(sub_method, sub_options)

--- a/spec/controllers/api/prediction_judgements_controller_spec.rb
+++ b/spec/controllers/api/prediction_judgements_controller_spec.rb
@@ -21,7 +21,7 @@ describe Api::PredictionJudgementsController, type: :controller do
         expect(prediction).to receive(:judge!).with('right', user)
 
         expect(User).to receive(:find_by).with(api_token: 'real-token').and_return(user)
-        expect(user).to receive(:authorized_for).with(prediction).and_return(true)
+        expect(user).to receive(:authorized_for).with([], prediction).and_return(true)
       end
 
       it 'judges the prediction' do

--- a/spec/controllers/api/predictions_controller_spec.rb
+++ b/spec/controllers/api/predictions_controller_spec.rb
@@ -74,6 +74,40 @@ describe Api::PredictionsController, type: :controller do
         specify { expect(response).to_not be_success }
         specify { expect(response.body).to include('a probability is between') }
       end
+
+      context 'with new visibility' do
+        let(:prediction_params) do
+          {
+            description: 'The world will end tomorrow!',
+            deadline: 1.day.ago,
+            initial_confidence: '100',
+            visibility: 'visible_to_creator'
+          }
+        end
+
+        before { post :create, prediction: prediction_params, api_token: user.api_token }
+
+        specify do
+          expect(Prediction.last.visible_to_creator?).to be true
+        end
+      end
+
+      context 'with old private flag' do
+        let(:prediction_params) do
+          {
+            description: 'The world will end tomorrow!',
+            deadline: 1.day.ago,
+            initial_confidence: '100',
+            private: true
+          }
+        end
+
+        before { post :create, prediction: prediction_params, api_token: user.api_token }
+
+        specify do
+          expect(Prediction.last.visible_to_creator?).to be true
+        end
+      end
     end
 
     context 'with invalid API token' do

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe GroupsController do
+  describe 'GET index' do
+    subject(:index) { get :index }
+
+    context 'not logged in' do
+      specify do
+        index
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context 'logged in' do
+      before { sign_in FactoryGirl.create(:user, email: 'bob@trikeapps.com') }
+
+      specify do
+        expect { index }.to raise_error ActionController::RoutingError
+      end
+
+      context 'no matching group exists' do
+        before { FactoryGirl.create(:group, email_domains: 'trickapps.com') }
+
+        specify do
+          expect { index }.to raise_error ActionController::RoutingError
+        end
+      end
+
+      context 'matching group exists' do
+        before { FactoryGirl.create(:group, email_domains: 'trikeapps.com') }
+
+        specify do
+          index
+          expect(response).to render_template :index
+        end
+      end
+    end
+  end
+
+  describe 'GET show' do
+    subject(:show) { get :show, id: group.id }
+
+    let(:group) { FactoryGirl.create(:group, email_domains: 'trikeapps.com') }
+
+    context 'not logged in' do
+      specify do
+        show
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context 'logged in' do
+      before { sign_in FactoryGirl.create(:user, email: email) }
+
+      let(:email) { 'bob@trikeapps.com' }
+
+      specify do
+        show
+        expect(response).to render_template :show
+      end
+
+      context 'email does not match group' do
+        let(:email) { 'bob@trickapps.com' }
+
+        specify do
+          expect { show }.to raise_error ActionController::RoutingError
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -32,6 +32,7 @@ describe GroupsController do
         specify do
           index
           expect(response).to render_template :index
+          expect(assigns[:groups]).not_to be_nil
         end
       end
     end
@@ -57,6 +58,8 @@ describe GroupsController do
       specify do
         show
         expect(response).to render_template :show
+        expect(assigns[:group]).not_to be_nil
+        expect(assigns[:predictions]).not_to be_nil
       end
 
       context 'email does not match group' do

--- a/spec/controllers/predictions_controller_spec.rb
+++ b/spec/controllers/predictions_controller_spec.rb
@@ -183,6 +183,17 @@ describe PredictionsController do
           end
         end
 
+        context 'when prediction privacy is group' do
+          let(:params) { { visibility: 'visible_to_group_345' } }
+
+          specify do
+            expect(Prediction).to receive(:create!)
+              .with(hash_including('visibility' => 'visible_to_group', 'group_id' => 345))
+              .and_return(prediction)
+            create
+          end
+        end
+
         context 'when prediction privacy is not provided' do
           let(:params) { { visibility: logged_in_user.visibility_default } }
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -103,4 +103,32 @@ describe UsersController do
       end
     end
   end
+
+  describe 'PUT update' do
+    subject(:update) { put :update, id: user_id, user: user_params }
+
+    let(:group) { FactoryGirl.create(:group) }
+    let(:user_params) { { visibility_default: "visible_to_group_#{group.id}" } }
+
+    context 'not logged in user' do
+      let(:user_id) { FactoryGirl.create(:user).id }
+
+      specify do
+        update
+        expect(response).to be_forbidden
+      end
+    end
+
+    context 'logged in user' do
+      let(:user_id) { logged_in_user.id }
+
+      specify do
+        update
+        expect(response).to render_template :show
+        logged_in_user.reload
+        expect(logged_in_user.visibility_default).to eq 'visible_to_group'
+        expect(logged_in_user.group_default_id).to eq group.id
+      end
+    end
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -33,7 +33,7 @@ describe UsersController do
     context 'logged in user and target user are different' do
       specify do
         predictions = class_double(Prediction)
-        expect(relation).to receive(:not_private).and_return predictions
+        expect(relation).to receive(:visible_to_everyone).and_return predictions
         paged_predictions = class_double(Prediction)
         expect(predictions).to receive(:page).and_return(paged_predictions)
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -94,4 +94,9 @@ FactoryGirl.define do
     sequence(:value)
     sequence(:rank)
   end
+
+  factory :group do
+    name { FFaker::Name.name }
+    email_domains { nil }
+  end
 end

--- a/spec/features/predictions_spec.rb
+++ b/spec/features/predictions_spec.rb
@@ -26,4 +26,28 @@ feature 'creating and modifying predictions' do
     expect(current_path).to eq prediction_path(prediction)
     expect(page).to have_content 'A new prediction'
   end
+
+  scenario 'when user has set a visibility default' do
+    user.update_attributes(visibility_default: 'visible_to_creator')
+
+    visit new_prediction_path
+    fill_in 'prediction_description', with: 'Desc'
+    fill_in 'prediction_initial_confidence', with: '55'
+    fill_in 'prediction_deadline_text', with: '1 day from now'
+    click_button 'Lock it in!'
+
+    expect(page).to have_content 'This prediction is private'
+
+    visit predictions_path
+
+    expect(page).not_to have_content 'Desc'
+    expect(page).not_to have_content 'known in 1 day'
+    expect(page).not_to have_content 'estimated 55%'
+
+    visit user_path(user)
+
+    expect(page).to have_content 'Desc'
+    expect(page).to have_content 'known in 1 day'
+    expect(page).to have_content '55% confidence'
+  end
 end

--- a/spec/helpers/version_helper_spec.rb
+++ b/spec/helpers/version_helper_spec.rb
@@ -42,18 +42,18 @@ describe VersionHelper do
       it { is_expected.to eq 'withdrew the prediction' }
     end
 
-    context 'private is changing' do
-      let(:field) { :private }
-      let(:old_value) { !new_value }
+    context 'visibility is changing' do
+      let(:field) { :visibility }
+      let(:old_value) { 0 }
 
       context 'made private' do
-        let(:new_value) { true }
-        it { is_expected.to eq 'made the prediction private' }
+        let(:new_value) { 1 }
+        it { is_expected.to eq 'made the prediction visible to creator' }
       end
 
-      context 'made public' do
-        let(:new_value) { false }
-        it { is_expected.to eq 'made the prediction public' }
+      context 'made visible to group' do
+        let(:new_value) { 2 }
+        it { is_expected.to eq 'made the prediction visible to group' }
       end
     end
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe Group, type: :model do
+  describe 'validations' do
+    subject { group.valid? }
+
+    let(:group) { FactoryGirl.build(:group, name: 'something', email_domains: email_domains) }
+
+    context 'nil email_domains' do
+      let(:email_domains) { nil }
+
+      it { is_expected.to be true }
+    end
+
+    context 'invalid email_domains' do
+      let(:email_domains) { 'some string' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'single email_domain' do
+      let(:email_domains) { 'trikeapps.com' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'multiple email_domains' do
+      let(:email_domains) { 'trikeapps.com,some.other.com' }
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe Group, type: :model do
+  let(:group) { FactoryGirl.build(:group, name: 'something', email_domains: email_domains) }
+
   describe 'validations' do
     subject { group.valid? }
-
-    let(:group) { FactoryGirl.build(:group, name: 'something', email_domains: email_domains) }
 
     context 'nil email_domains' do
       let(:email_domains) { nil }
@@ -26,6 +26,37 @@ RSpec.describe Group, type: :model do
 
     context 'multiple email_domains' do
       let(:email_domains) { 'trikeapps.com,some.other.com' }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe 'user_is_a_member?' do
+    subject(:user_is_a_member?) { group.user_is_a_member?(user) }
+
+    let(:user) { FactoryGirl.build(:user, email: 'big.billy.bob@trikeapps.com') }
+    let(:email_domains) { 'trikeapps.com,some.other.com' }
+
+    context 'no email domains' do
+      let(:email_domains) { nil }
+
+      it { is_expected.to be false }
+    end
+
+    context 'mismatching email domains' do
+      let(:email_domains) { 'gmail.com,yahoo.com' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'matching email domains' do
+      let(:email_domains) { 'trikeapps.com,some.other.com' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'matching email domains at end of list' do
+      let(:email_domains) { 'some.other.com,trikeapps.com' }
 
       it { is_expected.to be true }
     end

--- a/spec/models/prediction_version_spec.rb
+++ b/spec/models/prediction_version_spec.rb
@@ -13,8 +13,7 @@ describe PredictionVersion do
       let(:user) { FactoryGirl.create(:user) }
       let!(:prediction) do
         FactoryGirl.build(:prediction, description: 'A description', deadline: Date.yesterday,
-                                       creator: user, uuid: 'uuid1', withdrawn: true,
-                                       private: false)
+                                       creator: user, uuid: 'uuid1', withdrawn: true)
       end
 
       specify do
@@ -25,7 +24,7 @@ describe PredictionVersion do
         expect(version.description).to eq 'A description'
         expect(version.deadline).to eq Date.yesterday
         expect(version.withdrawn).to be true
-        expect(version.private).to be false
+        expect(version.visibility).to eq 'visible_to_everyone'
       end
     end
   end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -29,7 +29,7 @@ describe Response do
       end
       it 'calls rsort and public scopes' do
         expect(Response).to receive(:order).and_return(@rs)
-        expect(Response).to receive(:not_private).and_return(@rs)
+        expect(Response).to receive(:visible_to_everyone).and_return(@rs)
         expect(Response).to receive(:prefetch_joins).and_return(@rs)
         expect(Response).to receive(:limit).and_return(@rs)
         expect(Response.recent).to eq @rs

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ describe User do
   end
 
   it 'has a private_default field which defaults to false' do
-    expect(User.new.private_default).to be false
+    expect(User.new.visible_to_everyone?).to be true
   end
 
   it 'has an email with name' do
@@ -44,23 +44,27 @@ describe User do
   end
 
   describe 'authorized_for' do
-    it 'is true for predictions created by self' do
-      @user = User.new
-      @prediction = @user.predictions.build(creator: @user)
-      expect(@user.authorized_for(@prediction)).to eq true
+    subject { user.authorized_for(prediction) }
+
+    let(:user) { User.new }
+    let(:creator_user) { user }
+    let(:prediction) do
+      user.predictions.build(creator: creator_user, visibility: :visible_to_creator)
     end
-    it 'is false for predictions not created by self' do
-      @user = User.new
-      @user2 = User.new
-      @prediction = @user2.predictions.build(creator: @user2)
-      expect(@user.authorized_for(@prediction)).to eq false
+
+    it { is_expected.to be true }
+
+    context 'not created by user' do
+      let(:creator_user) { User.new }
+
+      it { is_expected.to be false }
     end
-    it 'is true for admins' do
-      @user = User.new
-      expect(@user).to receive(:admin?).and_return(true)
-      @user2 = User.new
-      @prediction = @user.predictions.build(creator: @user2)
-      expect(@user.authorized_for(@prediction)).to eq true
+
+    context 'not created by user by user is admin' do
+      let(:user) { User.new(login: 'matt') }
+      let(:creator_user) { User.new }
+
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,10 +44,12 @@ describe User do
   end
 
   describe 'authorized_for' do
-    subject { user.authorized_for(prediction) }
+    subject { user.authorized_for(groups, prediction, action) }
 
     let(:user) { User.new }
     let(:creator_user) { user }
+    let(:groups) { [] }
+    let(:action) { 'edit' }
     let(:prediction) do
       user.predictions.build(creator: creator_user, visibility: :visible_to_creator)
     end
@@ -58,13 +60,33 @@ describe User do
       let(:creator_user) { User.new }
 
       it { is_expected.to be false }
-    end
 
-    context 'not created by user by user is admin' do
-      let(:user) { User.new(login: 'matt') }
-      let(:creator_user) { User.new }
+      context 'user is admin' do
+        let(:user) { User.new(login: 'matt') }
+        let(:creator_user) { User.new }
 
-      it { is_expected.to be true }
+        it { is_expected.to be true }
+      end
+
+      context 'prediction in group' do
+        let(:group) { FactoryGirl.create(:group) }
+        let(:prediction) do
+          user.predictions.build(creator: creator_user, visibility: :visible_to_group, group: group)
+        end
+        let(:action) { 'show' }
+
+        context 'user in group' do
+          let(:groups) { [group] }
+
+          it { is_expected.to be true }
+        end
+
+        context 'user not in group' do
+          let(:groups) { [FactoryGirl.create(:group)] }
+
+          it { is_expected.to be false }
+        end
+      end
     end
   end
 end

--- a/spec/models/visibility_spec.rb
+++ b/spec/models/visibility_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Visibility do
+  describe '.select_options_html' do
+    subject(:html) do
+      described_class.select_options_html([group], current_visibility, current_group_id)
+    end
+
+    let(:current_visibility) { 'visible_to_creator' }
+    let(:current_group_id) { nil }
+    let(:group) { FactoryGirl.create(:group, name: 'TrikeApps') }
+
+    specify do
+      expect(html).to eq '<option value="visible_to_everyone" >Visible to everyone</option>' \
+                         '<option value="visible_to_creator" selected>Visible to creator</option>' \
+                         "<option value=\"visible_to_group_#{group.id}\" >Visible to TrikeApps group</option>"
+    end
+
+    context 'visible to group but not this group' do
+      let(:current_visibility) { 'visible_to_group' }
+      let(:current_group_id) { group.id - 1 }
+
+      specify do
+        expect(html).to eq '<option value="visible_to_everyone" >Visible to everyone</option>' \
+                           '<option value="visible_to_creator" >Visible to creator</option>' \
+                           "<option value=\"visible_to_group_#{group.id}\" >Visible to TrikeApps group</option>"
+      end
+    end
+
+    context 'visible to group but not this group' do
+      let(:current_visibility) { 'visible_to_group' }
+      let(:current_group_id) { group.id }
+
+      specify do
+        expect(html).to eq '<option value="visible_to_everyone" >Visible to everyone</option>' \
+                           '<option value="visible_to_creator" >Visible to creator</option>' \
+                           "<option value=\"visible_to_group_#{group.id}\" selected>Visible to TrikeApps group</option>"
+      end
+    end
+  end
+end

--- a/spec/views/predictions/new.html.erb_spec.rb
+++ b/spec/views/predictions/new.html.erb_spec.rb
@@ -7,6 +7,7 @@ describe 'predictions/new' do
   before(:each) do
     assign(:prediction, prediction)
     assign(:statistics, Statistics.new)
+    assign(:groups, [])
     allow(view).to receive(:user_statistics_cache_key).and_return 'stats'
     allow(view).to receive(:current_user).and_return(user)
   end

--- a/spec/views/predictions/new.html.erb_spec.rb
+++ b/spec/views/predictions/new.html.erb_spec.rb
@@ -52,22 +52,10 @@ describe 'predictions/new' do
     end
   end
 
-  describe '(check box for private)' do
+  describe '(select for visibility)' do
     it 'is present' do
       render
-      expect(rendered).to have_field('prediction[private]')
-    end
-
-    it 'is checked when user private_default is true' do
-      expect(prediction).to receive(:private).and_return true
-      render
-      expect(rendered).to have_checked_field('prediction[private]')
-    end
-
-    it 'is not checked when user private_default is false' do
-      expect(prediction).to receive(:private).and_return false
-      render
-      expect(rendered).to_not have_checked_field('prediction[private]')
+      expect(rendered).to have_field('prediction[visibility]')
     end
   end
 

--- a/spec/views/users/settings.html.erb_spec.rb
+++ b/spec/views/users/settings.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'users/settings' do
-  describe 'private_default checkbox' do
+  describe 'visibility_default checkbox' do
     before do
       assigns[:user] = @user = FactoryGirl.create(:user)
       allow(view).to receive(:current_user).and_return(@user)
@@ -11,23 +11,11 @@ describe 'users/settings' do
 
     it 'exists' do
       render
-      expect(rendered).to have_field('user[private_default]')
-    end
-
-    it 'is checked if the user wishes it' do
-      allow(@user).to receive(:private_default).and_return(true)
-      render
-      expect(rendered).to have_checked_field('user[private_default]')
-    end
-
-    it 'is not checked if the user does not wish it' do
-      allow(@user).to receive(:private_default).and_return(false)
-      render
-      expect(rendered).to have_unchecked_field('user[private_default]')
+      expect(rendered).to have_field('user[visibility_default]')
     end
 
     it 'displays API token' do
-      allow(@user).to receive(:private_default).and_return(false)
+      allow(@user).to receive(:visibility_default).and_return(false)
       render
       expect(rendered).to have_content('token')
     end

--- a/spec/views/users/settings.html.erb_spec.rb
+++ b/spec/views/users/settings.html.erb_spec.rb
@@ -4,6 +4,7 @@ describe 'users/settings' do
   describe 'visibility_default checkbox' do
     before do
       assigns[:user] = @user = FactoryGirl.create(:user)
+      @groups = []
       allow(view).to receive(:current_user).and_return(@user)
       allow(@user).to receive(:api_token).and_return('token')
       allow(@user).to receive(:id).and_return(1)


### PR DESCRIPTION
Background: TrikeApps has a (relatively) urgent need to use PredictionBook as a repository for predictions about user stories, but the information in those predictions is likely to be sensitive. We have been asked several times to create private instances of the site, but this means that individuals (like me) who are members of multiple instances don't get to incorporate all the useful calibration data across all those predictions.

Intention: Allow private groups to exist on PredictionBook, initially only available to members with emails in specific domains (these groups will be added on production via console). Allow all members of those groups to set the visibility of a prediction to public, private, or visible only to members of a specific group.

This has deliberately been designed to be easily extensible, and it would be relatively simple to build the creation and membership management for private groups on top of this functionality for wider use.