### PR TITLE
Proper scoring rule redux

### DIFF
--- a/app/models/score_calculator.rb
+++ b/app/models/score_calculator.rb
@@ -1,0 +1,42 @@
+class ScoreCalculator
+  DECIMAL_PLACES = 2
+  DEFAULT_SCORE = 1
+  EPISILON = 0.005
+
+  attr_reader :wagers
+
+  def self.calculate(wagers)
+    new(wagers).calculate
+  end
+
+  def initialize(wagers)
+    @wagers = wagers.includes(prediction: [:judgements])
+  end
+
+  def calculate
+    return DEFAULT_SCORE if scorable_wagers.count.zero?
+    score = 0
+
+    scorable_wagers.each do |wager|
+      if wager.correct?
+        score += Math.log(percent_confidence(wager))
+      else
+        score += Math.log(1 - percent_confidence(wager))
+      end
+    end
+
+    ((Math.log(0.5) * scorable_wagers.count) / score).round(DECIMAL_PLACES)
+  end
+
+  private
+
+  def percent_confidence(wager)
+    percent = wager.relative_confidence / 100.0
+    return 1 - EPISILON if percent == 1
+    percent
+  end
+
+  def scorable_wagers
+    @scorable_wagers ||= wagers.reject { |wager| wager.unknown? }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,6 +109,10 @@ class User < ActiveRecord::Base
       Devise::Encryptor.compare(self.class, encrypted_password, password)
   end
 
+  def reset_score
+    update(score: ScoreCalculator.calculate(wagers))
+  end
+
   protected
 
   def old_password_digest(password, salt)

--- a/app/sweepers/statistics_sweeper.rb
+++ b/app/sweepers/statistics_sweeper.rb
@@ -4,8 +4,11 @@ class StatisticsSweeper < ActionController::Caching::Sweeper
   include CacheKeys
 
   def after_create(judgement)
-    judgement.prediction.wagers.collect(&:user).each do |user|
+    associated_users = judgement.prediction.wagers.collect(&:user).uniq
+
+    associated_users.each do |user|
       Rails.cache.clear(user_statistics_cache_key(user))
+      user.reset_score
     end
 
     Rails.cache.clear(global_statistics_cache_key)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,6 +3,10 @@
   	<%= render :partial => 'statistics/show' %>
   <%- end -%>
 
+  <div id="score">
+    <h2>Calibration Score: <%= @user.score %></h2>
+  </div>
+
   <div id="predictions">
     <h2>Most recent predictions by <%= show_user(@user) %></h2>
     <ul>

--- a/db/migrate/20170413060851_add_score_to_users.rb
+++ b/db/migrate/20170413060851_add_score_to_users.rb
@@ -1,0 +1,5 @@
+class AddScoreToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :score, :float, default: 1.0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170412121536) do
+ActiveRecord::Schema.define(version: 20170413060851) do
 
   create_table "credence_answers", force: :cascade do |t|
     t.integer  "credence_question_id", limit: 4
@@ -167,6 +167,7 @@ ActiveRecord::Schema.define(version: 20170412121536) do
     t.string   "last_sign_in_ip",           limit: 255
     t.integer  "visibility_default",        limit: 4,   default: 0,     null: false
     t.integer  "group_default_id",          limit: 4
+    t.float    "score",                     limit: 24,  default: 1.0
   end
 
   add_index "users", ["api_token"], name: "index_users_on_api_token", using: :btree

--- a/spec/models/score_calculator_spec.rb
+++ b/spec/models/score_calculator_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe ScoreCalculator do
+  let(:user) { FactoryGirl.create(:user) }
+
+  describe '.calculate' do
+    context 'without any wagers' do
+      let(:wagers) { Response.none }
+
+      it { expect(ScoreCalculator.calculate(wagers)).to eq(1) }
+    end
+
+    context 'with a wager on an unjudged prediction' do
+      let!(:wager) { FactoryGirl.create(:response, confidence: 50) }
+      let!(:judgment) do
+        FactoryGirl.create(
+          :judgement,
+          prediction: wager.prediction,
+          outcome: nil
+        )
+      end
+      let!(:wagers) { wager.user.wagers }
+
+      it { expect(ScoreCalculator.calculate(wagers)).to eq(1) }
+    end
+
+    context 'with a wager on a judged prediction' do
+      let!(:wager) { FactoryGirl.create(:response, confidence: 80) }
+      let!(:judgment) do
+        FactoryGirl.create(
+          :judgement,
+          prediction: wager.prediction,
+          outcome: 'right'
+        )
+      end
+      let!(:wagers) { wager.user.wagers }
+
+      it { expect(ScoreCalculator.calculate(wagers)).to eq(3.11) }
+    end
+
+    context 'with multiple wagers on judged predictions' do
+      let!(:user) { FactoryGirl.create(:user) }
+      let!(:first_wager) do
+        FactoryGirl.create(:response, confidence: 90, user: user)
+      end
+      let!(:first_judgment) do
+        FactoryGirl.create(
+          :judgement,
+          prediction: first_wager.prediction,
+          outcome: 'wrong'
+        )
+      end
+      let!(:second_wager) do
+        FactoryGirl.create(:response, confidence: 70, user: user)
+      end
+      let!(:second_judgment) do
+        FactoryGirl.create(
+          :judgement,
+          prediction: second_wager.prediction,
+          outcome: 'right'
+        )
+      end
+      let!(:third_wager) do
+        FactoryGirl.create(:response, confidence: 30, user: user)
+      end
+      let!(:third_judgment) do
+        FactoryGirl.create(
+          :judgement,
+          prediction: third_wager.prediction,
+          outcome: 'wrong'
+        )
+      end
+      let!(:wagers) { user.wagers }
+
+      it { expect(ScoreCalculator.calculate(wagers)).to eq(0.69) }
+    end
+  end
+end


### PR DESCRIPTION
Here's a preliminary implementation of calibration scoring. [This](https://github.com/tricycle/predictionbook/commit/7b551990f2f84fdec815aff40afe49fce88e9d54) was a earlier attempt from which I drew inspiration, but it was far too slow for production use. This still has many possible performance enhancements, but I wanted to get this out there for criticism before I spend any time optimizing.

Once scores are stored in the `users` table, adding a (performant) leaderboard like [this](https://github.com/tricycle/predictionbook/pull/56) should become trivial.