### PR TITLE
Update schema to Rails 5.2.0

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,199 +10,189 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170626055158) do
+ActiveRecord::Schema.define(version: 2017_06_26_055158) do
 
-  create_table "credence_answers", force: :cascade do |t|
-    t.integer  "credence_question_id", limit: 4
-    t.text     "text",                 limit: 65535
-    t.text     "value",                limit: 65535
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
-    t.integer  "rank",                 limit: 4
+  create_table "credence_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "credence_question_id"
+    t.text "text"
+    t.text "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "rank"
+    t.index ["credence_question_id"], name: "index_credence_answers_on_credence_question_id"
   end
 
-  add_index "credence_answers", ["credence_question_id"], name: "index_credence_answers_on_credence_question_id", using: :btree
-
-  create_table "credence_game_responses", force: :cascade do |t|
-    t.integer  "credence_question_id", limit: 4
-    t.integer  "first_answer_id",      limit: 4
-    t.integer  "second_answer_id",     limit: 4
-    t.integer  "correct_index",        limit: 4
-    t.integer  "credence_game_id",     limit: 4
+  create_table "credence_game_responses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "credence_question_id"
+    t.integer "first_answer_id"
+    t.integer "second_answer_id"
+    t.integer "correct_index"
+    t.integer "credence_game_id"
     t.datetime "asked_at"
     t.datetime "answered_at"
-    t.integer  "answer_credence",      limit: 4
-    t.integer  "given_answer",         limit: 4
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.integer "answer_credence"
+    t.integer "given_answer"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["credence_game_id", "asked_at"], name: "index_credence_game_responses_on_credence_game_id_and_asked_at"
+    t.index ["credence_question_id"], name: "index_credence_game_responses_on_credence_question_id"
   end
 
-  add_index "credence_game_responses", ["credence_game_id", "asked_at"], name: "index_credence_game_responses_on_credence_game_id_and_asked_at", using: :btree
-  add_index "credence_game_responses", ["credence_question_id"], name: "index_credence_game_responses_on_credence_question_id", using: :btree
-
-  create_table "credence_games", force: :cascade do |t|
-    t.integer  "current_response_id", limit: 4
-    t.integer  "score",               limit: 4, default: 0, null: false
-    t.integer  "user_id",             limit: 4
-    t.integer  "num_answered",        limit: 4, default: 0, null: false
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
+  create_table "credence_games", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "current_response_id"
+    t.integer "score", default: 0, null: false
+    t.integer "user_id"
+    t.integer "num_answered", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_credence_games_on_user_id", unique: true
   end
 
-  add_index "credence_games", ["user_id"], name: "index_credence_games_on_user_id", unique: true, using: :btree
-
-  create_table "credence_questions", force: :cascade do |t|
-    t.boolean  "enabled"
-    t.string   "text",            limit: 255
-    t.string   "prefix",          limit: 255
-    t.string   "suffix",          limit: 255
-    t.string   "question_type",   limit: 255
-    t.integer  "adjacent_within", limit: 4
-    t.float    "weight",          limit: 24
-    t.string   "text_id",         limit: 50
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+  create_table "credence_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.boolean "enabled"
+    t.string "text"
+    t.string "prefix"
+    t.string "suffix"
+    t.string "question_type"
+    t.integer "adjacent_within"
+    t.float "weight"
+    t.string "text_id", limit: 50
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["text_id"], name: "index_credence_questions_on_text_id", unique: true
   end
 
-  add_index "credence_questions", ["text_id"], name: "index_credence_questions_on_text_id", unique: true, using: :btree
-
-  create_table "group_members", force: :cascade do |t|
-    t.integer  "group_id",   limit: 4
-    t.integer  "user_id",    limit: 4
-    t.integer  "role",       limit: 4
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.string   "uuid",       limit: 255
+  create_table "group_members", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "group_id"
+    t.integer "user_id"
+    t.integer "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "uuid"
+    t.index ["group_id"], name: "index_group_members_on_group_id"
+    t.index ["user_id"], name: "index_group_members_on_user_id"
   end
 
-  add_index "group_members", ["group_id"], name: "index_group_members_on_group_id", using: :btree
-  add_index "group_members", ["user_id"], name: "index_group_members_on_user_id", using: :btree
-
-  create_table "groups", force: :cascade do |t|
-    t.string   "name",       limit: 255, null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+  create_table "groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "judgements", force: :cascade do |t|
-    t.integer  "prediction_id", limit: 4
-    t.integer  "user_id",       limit: 4
-    t.boolean  "outcome"
+  create_table "judgements", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "prediction_id"
+    t.integer "user_id"
+    t.boolean "outcome"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["prediction_id"], name: "index_judgements_on_prediction_id"
+    t.index ["user_id"], name: "index_judgements_on_user_id"
   end
 
-  add_index "judgements", ["prediction_id"], name: "index_judgements_on_prediction_id", using: :btree
-  add_index "judgements", ["user_id"], name: "index_judgements_on_user_id", using: :btree
-
-  create_table "notifications", force: :cascade do |t|
-    t.integer  "prediction_id", limit: 4
-    t.integer  "user_id",       limit: 4
-    t.boolean  "sent",                      default: false
+  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "prediction_id"
+    t.integer "user_id"
+    t.boolean "sent", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "enabled",                   default: true
-    t.string   "uuid",          limit: 255
-    t.boolean  "token_used",                default: false
-    t.string   "type",          limit: 255
-    t.boolean  "new_activity",              default: false
+    t.boolean "enabled", default: true
+    t.string "uuid"
+    t.boolean "token_used", default: false
+    t.string "type"
+    t.boolean "new_activity", default: false
+    t.index ["prediction_id"], name: "index_deadline_notifications_on_prediction_id"
+    t.index ["user_id"], name: "index_deadline_notifications_on_user_id"
   end
 
-  add_index "notifications", ["prediction_id"], name: "index_deadline_notifications_on_prediction_id", using: :btree
-  add_index "notifications", ["user_id"], name: "index_deadline_notifications_on_user_id", using: :btree
-
-  create_table "prediction_groups", force: :cascade do |t|
-    t.string   "description", limit: 255
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+  create_table "prediction_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "prediction_versions", force: :cascade do |t|
-    t.integer  "prediction_id", limit: 4
-    t.integer  "version",       limit: 4
-    t.string   "description",   limit: 255
+  create_table "prediction_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "prediction_id"
+    t.integer "version"
+    t.string "description"
     t.datetime "deadline"
-    t.integer  "creator_id",    limit: 4
-    t.string   "uuid",          limit: 255
-    t.boolean  "withdrawn",                 default: false
+    t.integer "creator_id"
+    t.string "uuid"
+    t.boolean "withdrawn", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "visibility",    limit: 4,   default: 0,     null: false
+    t.integer "visibility", default: 0, null: false
   end
 
-  create_table "predictions", force: :cascade do |t|
-    t.string   "description",         limit: 255
+  create_table "predictions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "description"
     t.datetime "deadline"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "creator_id",          limit: 4
-    t.string   "uuid",                limit: 255
-    t.boolean  "withdrawn",                       default: false
-    t.integer  "version",             limit: 4,   default: 1
-    t.integer  "visibility",          limit: 4,   default: 0,     null: false
-    t.integer  "group_id",            limit: 4
-    t.integer  "prediction_group_id", limit: 4
+    t.integer "creator_id"
+    t.string "uuid"
+    t.boolean "withdrawn", default: false
+    t.integer "version", default: 1
+    t.integer "visibility", default: 0, null: false
+    t.integer "group_id"
+    t.integer "prediction_group_id"
+    t.index ["creator_id"], name: "index_predictions_on_creator_id"
+    t.index ["group_id"], name: "index_predictions_on_group_id"
+    t.index ["prediction_group_id"], name: "index_predictions_on_prediction_group_id"
+    t.index ["uuid"], name: "index_predictions_on_uuid", unique: true
+    t.index ["visibility"], name: "index_predictions_on_visibility"
   end
 
-  add_index "predictions", ["creator_id"], name: "index_predictions_on_creator_id", using: :btree
-  add_index "predictions", ["group_id"], name: "index_predictions_on_group_id", using: :btree
-  add_index "predictions", ["prediction_group_id"], name: "index_predictions_on_prediction_group_id", using: :btree
-  add_index "predictions", ["uuid"], name: "index_predictions_on_uuid", unique: true, using: :btree
-  add_index "predictions", ["visibility"], name: "index_predictions_on_visibility", using: :btree
-
-  create_table "responses", force: :cascade do |t|
-    t.integer  "prediction_id", limit: 4
-    t.integer  "confidence",    limit: 4
+  create_table "responses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "prediction_id"
+    t.integer "confidence"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "comment",       limit: 255
-    t.integer  "user_id",       limit: 4
+    t.string "comment"
+    t.integer "user_id"
+    t.index ["prediction_id"], name: "index_responses_on_prediction_id"
+    t.index ["user_id"], name: "index_responses_on_user_id"
   end
 
-  add_index "responses", ["prediction_id"], name: "index_responses_on_prediction_id", using: :btree
-  add_index "responses", ["user_id"], name: "index_responses_on_user_id", using: :btree
-
-  create_table "users", force: :cascade do |t|
-    t.string   "login",                     limit: 255
-    t.string   "name",                      limit: 255
-    t.string   "email",                     limit: 255
-    t.string   "crypted_password",          limit: 40
-    t.string   "salt",                      limit: 40
-    t.string   "remember_token",            limit: 40
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "login"
+    t.string "name"
+    t.string "email"
+    t.string "crypted_password", limit: 40
+    t.string "salt", limit: 40
+    t.string "remember_token", limit: 40
     t.datetime "remember_token_expires_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "timezone",                  limit: 255
-    t.boolean  "admin",                                 default: false, null: false
-    t.string   "api_token",                 limit: 255
-    t.string   "encrypted_password",        limit: 255, default: "",    null: false
-    t.string   "reset_password_token",      limit: 255
+    t.string "timezone"
+    t.boolean "admin", default: false, null: false
+    t.string "api_token"
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",             limit: 4,   default: 0,     null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",        limit: 255
-    t.string   "last_sign_in_ip",           limit: 255
-    t.integer  "visibility_default",        limit: 4,   default: 0,     null: false
-    t.integer  "group_default_id",          limit: 4
-    t.string   "confirmation_token",        limit: 255
-    t.string   "unconfirmed_email",         limit: 255
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.integer "visibility_default", default: 0, null: false
+    t.integer "group_default_id"
+    t.string "confirmation_token"
+    t.string "unconfirmed_email"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.index ["api_token"], name: "index_users_on_api_token"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["group_default_id"], name: "index_users_on_group_default_id"
+    t.index ["login"], name: "index_users_on_login", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_index "users", ["api_token"], name: "index_users_on_api_token", using: :btree
-  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["group_default_id"], name: "index_users_on_group_default_id", using: :btree
-  add_index "users", ["login"], name: "index_users_on_login", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
-
-  create_table "wagers", force: :cascade do |t|
-    t.integer  "prediction_id", limit: 4
-    t.string   "name",          limit: 255
-    t.integer  "confidence",    limit: 4
+  create_table "wagers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "prediction_id"
+    t.string "name"
+    t.integer "confidence"
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
Running `rake db:schema:load` was causing an error due to different integer sizes in table ids and their respective foreign keys. Migrating the database from scratch creates a new `db/schema.rb` file that is Rails 5.2.0 compatible and solves the bug.