### PR TITLE
Update Loofah to 2.2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)


### PR DESCRIPTION
This PR upgrades `loofah` to 2.2.3 to fix a security vulnerability:
https://github.com/flavorjones/loofah/issues/154