### PR TITLE
Filter predictions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -326,5 +326,4 @@ li.group_member {
 
 .prediction-filter {
 	display: inline;
-	margin-left: 10px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -323,3 +323,8 @@ li.group_member {
 .tooltip:hover .tooltiptext {
     visibility: visible;
 }
+
+.prediction-filter {
+	display: inline;
+	margin-left: 10px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -297,23 +297,23 @@ li.group_member {
 
 /* Tooltip container */
 .tooltip {
-    position: relative;
-    display: inline-block;
-    border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
 }
 
 /* Tooltip text */
 .tooltip .tooltiptext {
-    visibility: hidden;
-    width: 600px;
-    background-color: black;
-    color: #fff;
-    text-align: center;
-    padding: 5px 0;
-    border-radius: 6px;
+  visibility: hidden;
+  width: 600px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
 
-    position: absolute;
-    z-index: 1;
+  position: absolute;
+  z-index: 1;
 }
 
 .tooltiptext.brier {
@@ -321,7 +321,7 @@ li.group_member {
 }
 /* Show the tooltip text when you mouse over the tooltip container */
 .tooltip:hover .tooltiptext {
-    visibility: visible;
+  visibility: visible;
 }
 
 .prediction-filter {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,13 @@ class UsersController < ApplicationController
     @predictions = @user.predictions
     @statistics  = @user.statistics
     @predictions = @predictions.visible_to_everyone unless user_is_current_user?
+
+    case params[:filter]
+    when 'judged' then @predictions = @predictions.judged
+    when 'unjudged' then @predictions = @predictions.unjudged
+    when 'future' then @predictions = @predictions.future
+    end
+    @count = @predictions.count
     @predictions = @predictions.page(params[:page])
     @score_calculator = ScoreCalculator.new(@user, start_date: 6.months.ago, interval: 1.month)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,18 +7,9 @@ class UsersController < ApplicationController
   before_action :allow_iframe_requests, only: [:statistics]
 
   def show
-    @title       = "Most recent predictions by #{@user}"
-    @predictions = @user.predictions
-    @statistics  = @user.statistics
-    @predictions = @predictions.visible_to_everyone unless user_is_current_user?
-
-    case params[:filter]
-    when 'judged' then @predictions = @predictions.judged
-    when 'unjudged' then @predictions = @predictions.unjudged
-    when 'future' then @predictions = @predictions.future
-    end
-    @count = @predictions.count
-    @predictions = @predictions.page(params[:page])
+    @title = "Most recent predictions by #{@user}"
+    @predictions = PredictionFilter.filter(@user, current_user, params[:filter], params[:page])
+    @statistics = @user.statistics
     @score_calculator = ScoreCalculator.new(@user, start_date: 6.months.ago, interval: 1.month)
   end
 

--- a/app/queries/prediction_filter.rb
+++ b/app/queries/prediction_filter.rb
@@ -5,6 +5,10 @@ module PredictionFilter
     predictions = user.predictions
     predictions = predictions.visible_to_everyone unless current_user == user
 
+    # Since these methods from Prediction only filter visible_to_everyone
+    # predictions, self.filter won't include private predictions.
+    # TODO: improve Prediction's methods
+
     predictions =
       case filter
       when 'judged' then predictions.judged

--- a/app/queries/prediction_filter.rb
+++ b/app/queries/prediction_filter.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PredictionFilter
+  def self.filter(user, current_user, filter, page)
+    predictions = user.predictions
+    predictions = predictions.visible_to_everyone unless current_user == user
+
+    predictions =
+      case filter
+      when 'judged' then predictions.judged
+      when 'unjudged' then predictions.unjudged
+      when 'future' then predictions.future
+      else predictions
+      end
+
+    predictions.page(page)
+  end
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,7 +12,12 @@
 
   <div id="predictions">
     <h2><%= show_user(@user) %> has made <%= @count %> predictions. Displaying most recent ones: </h2>
-    
+
+    <%= form_tag @user, method: :get, class: "prediction-filter" do %>
+      <%= select_tag :filter, options_for_select([["All", ""], ["Judged", "judged"], ["Unjudged", "unjudged"], ["Future", "future"]]) %>
+      <%= submit_tag "Filter list" %>
+    <% end %>
+
     <ul>
       <%= render :partial => @predictions %>
     </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,13 +11,12 @@
   </div>
 
   <div id="predictions">
-    <h2><%= show_user(@user) %> has made <%= @count %> predictions. Displaying most recent ones: </h2>
-
-    <%= form_tag @user, method: :get, class: "prediction-filter" do %>
-      <%= select_tag :filter, options_for_select([["All", ""], ["Judged", "judged"], ["Unjudged", "unjudged"], ["Future", "future"]]) %>
-      <%= submit_tag "Filter list" %>
-    <% end %>
-
+    <h2>Displaying <%= params[:filter].empty? ? 'all' : params[:filter] %> predictions made by <%= show_user(@user) %>, filtered by:
+      <%= form_tag @user, method: :get, class: 'prediction-filter' do %>
+        <%= select_tag :filter, options_for_select(['all predictions', 'judged', 'unjudged', 'future'], params[:filter]) %>
+        <%= submit_tag 'Go!' %>
+      <% end %>
+    </h2>
     <ul>
       <%= render :partial => @predictions %>
     </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,8 @@
   </div>
 
   <div id="predictions">
-    <h2>Most recent predictions by <%= show_user(@user) %></h2>
+    <h2><%= show_user(@user) %> has made <%= @count %> predictions. Displaying most recent ones: </h2>
+    
     <ul>
       <%= render :partial => @predictions %>
     </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div id="predictions">
-    <h2>Displaying <%= params[:filter].empty? ? 'all' : params[:filter] %> predictions made by <%= show_user(@user) %>, filtered by:
+    <h2>Displaying <%= params[:filter].nil? ? 'all' : params[:filter] %> predictions made by <%= show_user(@user) %>, filtered by:
       <%= form_tag @user, method: :get, class: 'prediction-filter' do %>
         <%= select_tag :filter, options_for_select(['all predictions', 'judged', 'unjudged', 'future'], params[:filter]) %>
         <%= submit_tag 'Go!' %>

--- a/spec/queries/prediction_filter_spec.rb
+++ b/spec/queries/prediction_filter_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe PredictionFilter do
+  describe '.filter' do
+    let(:creator) { FactoryBot.create(:user, api_token: 'creator-token') }
+    # let(:visitor) { FactoryBot.create(:user, apt_token: 'visitor-token') }
+
+    before do
+      # TODO: make filtering include private predictions
+
+      FactoryBot.create_list(
+        :prediction,
+        11,
+        creator: creator,
+        deadline: 1.year.from_now
+      )
+
+      FactoryBot.create_list(
+        :prediction,
+        5,
+        creator: creator,
+        deadline: 2.days.ago
+      )
+
+      judged =
+        FactoryBot.create_list(
+          :prediction,
+          7,
+          creator: creator,
+          deadline: 2.days.ago
+        )
+
+      judged.each { |pred| pred.judge!([true, false].sample, creator) }
+    end
+
+    it 'expects predictions to exist' do
+      expect(Prediction.where(creator: creator).count).to eq(23)
+    end
+
+    it "filters the user's own judged predictions" do
+      predictions = described_class.filter(creator, creator, 'judged', 1)
+      expect(predictions.count).to eq(7)
+    end
+
+    it "filters the user's own unjudged predictions" do
+      predictions = described_class.filter(creator, creator, 'unjudged', 1)
+      expect(predictions.count).to eq(5)
+    end
+
+    it "filters the user's own future predictions" do
+      predictions = described_class.filter(creator, creator, 'future', 1)
+      expect(predictions.count).to eq(11)
+    end
+
+    it 'can give all predictions' do
+      predictions = described_class.filter(creator, creator, 'all predictions', 1)
+      expect(predictions.count).to eq(23)
+    end
+  end
+end


### PR DESCRIPTION
This actually implements a new feature I really wish PredBook had: filtering predictions on a user's page. It adds a dropdown where anyone viewing a user's page can choose to see only one kind of prediction: judged, (past) unjudged and future. There is a lot of room for improvement here, but just having this makes my own use of the website quite a lot better. I don't have to dredge through pages and pages of old judged predictions to get to the ones I care about the most, the unjudged ones.