### PR TITLE
 Users can delete their accounts

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :lookup_user, only: %i[show update settings due_for_judgement statistics]
-  before_action :authenticate_user!, only: %i[settings update generate_api_token]
-  before_action :user_must_be_current_user, only: %i[settings update]
+  before_action :lookup_user, only: %i[destroy show update settings due_for_judgement statistics]
+  before_action :authenticate_user!, only: %i[destroy settings update generate_api_token]
+  before_action :user_must_be_current_user, only: %i[destroy settings update]
   before_action :allow_iframe_requests, only: :statistics
+
+  def destroy
+    if current_user.pseudonymize! && current_user.destroy
+      redirect_to root_url
+    else
+      flash[:error] = 'The user record failed to be destroyed!'
+      redirect_to settings_user_url(current_user)
+    end
+  end
 
   def show
     @title = "Most recent predictions by #{@user}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  PSEUDONYMOUS_LOGIN = 'PseudonymousUser'
+
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable,
          :validatable, :confirmable
 
@@ -36,6 +38,10 @@ class User < ApplicationRecord
                       allow_nil: true
                     }
 
+  def self.pseudonymous_user
+    find_by(login: PSEUDONYMOUS_LOGIN)
+  end
+
   def self.find_for_database_authentication(warden_conditions)
     conditions = warden_conditions.dup
     login = conditions.delete(:login)
@@ -50,6 +56,10 @@ class User < ApplicationRecord
 
   def self.generate_api_token
     SecureRandom.urlsafe_base64
+  end
+
+  def pseudonymize!
+    UserPseudonymizer.call(self)
   end
 
   def predictions

--- a/app/models/user_pseudonymizer.rb
+++ b/app/models/user_pseudonymizer.rb
@@ -1,0 +1,41 @@
+class UserPseudonymizer
+  CREATOR_ASSOCIATIONS = [Prediction, PredictionVersion]
+  USER_ASSOCIATIONS = [Judgement, Response]
+
+  def self.call(user)
+    new(user).call
+  end
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    ApplicationRecord.transaction do
+      update_creator_associations
+      update_user_associations
+    end
+  end
+
+  private
+
+  attr_reader :user
+
+  def update_creator_associations
+    CREATOR_ASSOCIATIONS.each do |model|
+      model
+        .where(creator_id: user.id)
+        .update_all(creator_id: pseudonymous_user.id)
+    end
+  end
+
+  def update_user_associations
+    USER_ASSOCIATIONS.each do |model|
+      model.where(user_id: user.id).update_all(user_id: pseudonymous_user.id)
+    end
+  end
+
+  def pseudonymous_user
+    @pseudonymous_user ||= User.pseudonymous_user
+  end
+end

--- a/app/models/user_pseudonymizer.rb
+++ b/app/models/user_pseudonymizer.rb
@@ -15,6 +15,8 @@ class UserPseudonymizer
       update_creator_associations
       update_user_associations
     end
+
+    true
   end
 
   private

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -8,9 +8,8 @@
   <%= f.submit 'Change details' %>
 <% end %>
 <h2>Password</h2>
-<p>
-  <%= link_to 'Change password', edit_user_registration_path %>
-</p>
+<p><%= link_to 'Change password', edit_user_registration_path %></p>
+<p><%= link_to 'Delete my account!', user_path(@user), method: :delete, data: { confirm: 'Are you sure you want to delete your account? This action is irreversible.' } %></p>
 
 <h2><%= link_to 'View notifications', [@user,:deadline_notifications] %></h2>
 <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ PredictionBook::Application.routes.draw do
   devise_for :users
 
   # then the other stuff having to do with users
-  resources :users, only: %i[show update] do
+  resources :users, only: %i[destroy show update ] do
     # nested resources come before member/collection routes
     resources :deadline_notifications
     member do

--- a/lib/tasks/create_pseudonymous_user_record.rake
+++ b/lib/tasks/create_pseudonymous_user_record.rake
@@ -1,0 +1,11 @@
+namespace :db do
+  desc 'Create the pseudonymous user record'
+  task create_pseudonymous_user_record: :environment do
+    User.find_or_initialize_by(login: User::PSEUDONYMOUS_LOGIN).tap do |user|
+      password = User.generate_api_token
+      user.password = password
+      user.password_confirmation = password
+      user.email = 'pseudonymous-user@predictionbook.com'
+    end.save! and puts 'Successfully created the pseudonymous user record!'
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -58,6 +58,19 @@ describe UsersController do
     end
   end
 
+  describe '#destroy' do
+    subject(:destroy)   { delete :destroy, params: { id: user_id } }
+    let(:user_id) { logged_in_user.id }
+
+    it "pseudonymizes the user's associated records and deletes the account" do
+      FactoryBot.create(:user, :pseudonymous)
+      allow(logged_in_user).to receive(:pseudonymize!).and_return(true)
+      destroy
+      expect(response).to redirect_to root_path
+      expect(User.find_by(id: user_id)).to_not be
+    end
+  end
+
   describe 'users setting page' do
     subject(:settings) { get :settings, params: { id: user_id } }
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -65,6 +65,10 @@ FactoryBot.define do
     timezone { 'Melbourne' }
     confirmed_at { 1.day.ago }
     id { Random.rand(100_000) }
+
+    trait :pseudonymous do
+      login { User::PSEUDONYMOUS_LOGIN }
+    end
   end
 
   factory :deadline_notification do


### PR DESCRIPTION
Some users would like to delete their accounts (see [here](https://github.com/tricycle/predictionbook/issues/139) for an example), but doing so straightforwardly (`user.destroy`) would either result in broken associations between records or else to the destruction of data that arguably (at least partially) belongs to other users, such as would happen in the case where a user creates a prediction, another user wagers on that prediction, and then the first user deletes their account (and thereby causes that prediction to be deleted as a side-effect).

So, a slightly more roundabout strategy for handling account deletions would first create a general purpose user record, then replace the soon-to-be deleted user's place in all of it's associations (`user_id`, `creator_id`), and only after that actually delete that user record from the database.

This PR is one way to implement such a strategy, and can act as a concrete example that can inform the search for a good-enough strategy (if indeed this one turns out not to be).

**NOTE: After deploying, this command will need to be run before the feature will work as intended:**
`rails db:create_pseudonymous_user_record`
