### PR TITLE
 Users can always view predictions they wagered on

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,13 +96,7 @@ class User < ApplicationRecord
   end
 
   def authorized_for?(prediction, action = 'show')
-    is_creator = self == prediction.creator
-    user_group = groups.find { |ug| ug.id == prediction.group_id }
-    user_group_role = user_group.user_role(self) if user_group.present?
-    return true if is_creator || admin? || user_group_role == 'admin'
-    return false unless %w[index show].include?(action)
-
-    prediction.visible_to_everyone? || (prediction.visible_to_group? && user_group.present?)
+    UserAuthorizer.call(user: self, prediction: prediction, action: action)
   end
 
   def to_param

--- a/app/models/user_authorizer.rb
+++ b/app/models/user_authorizer.rb
@@ -13,7 +13,7 @@ class UserAuthorizer
     return true if privileged_user?
     return false unless read_only_action?
 
-    prediction.visible_to_everyone? || accessible_through_group?
+    prediction.visible_to_everyone? || accessible_through_group? || already_responded?
   end
 
   private
@@ -24,12 +24,20 @@ class UserAuthorizer
     prediction.visible_to_group? && user_group.present?
   end
 
+  def admin_role?
+    user_group_role == 'admin'
+  end
+
+  def already_responded?
+    prediction.responses.where(user: user).count.positive?
+  end
+
   def creator?
     user == prediction.creator
   end
 
   def privileged_user?
-    creator? || user.admin? || user_group_role == 'admin'
+    creator? || user.admin? || admin_role?
   end
 
   def read_only_action?

--- a/app/models/user_authorizer.rb
+++ b/app/models/user_authorizer.rb
@@ -1,0 +1,46 @@
+class UserAuthorizer
+  def self.call(user:, prediction:, action: 'show')
+    new(user: user, prediction: prediction, action: action).call
+  end
+
+  def initialize(user:, prediction:, action: 'show')
+    @user = user
+    @prediction = prediction
+    @action = action
+  end
+
+  def call
+    return true if privileged_user?
+    return false unless read_only_action?
+
+    prediction.visible_to_everyone? || accessible_through_group?
+  end
+
+  private
+
+  attr_reader :action, :prediction, :user
+
+  def accessible_through_group?
+    prediction.visible_to_group? && user_group.present?
+  end
+
+  def creator?
+    user == prediction.creator
+  end
+
+  def privileged_user?
+    creator? || user.admin? || user_group_role == 'admin'
+  end
+
+  def read_only_action?
+    %w[index show].include?(action)
+  end
+
+  def user_group
+    user.groups.find { |ug| ug.id == prediction.group_id }
+  end
+
+  def user_group_role
+    user_group.user_role(user) if user_group.present?
+  end
+end

--- a/spec/models/user_authorizer_spec.rb
+++ b/spec/models/user_authorizer_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe UserAuthorizer do
+  describe '.call' do
+    let(:action) { 'show' }
+    let(:another_user) { FactoryBot.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
+    subject do
+      described_class.call(user: user, prediction: prediction, action: action)
+    end
+
+    context 'for a user that made a wager' do
+      let(:wager) { FactoryBot.build(:response, confidence: 10, user: user) }
+
+      context 'on a prediction created by another user' do
+        let(:prediction) do
+          FactoryBot.create(
+            :prediction,
+            creator: another_user,
+            responses: [wager],
+            visibility: visibility
+          )
+        end
+
+        context 'that is still public' do
+          let(:visibility) { :visible_to_everyone }
+
+          it 'is authorized to show' do
+            expect(subject).to be(true)
+          end
+        end
+
+        context 'that has been made private' do
+          let(:visibility) { :visible_to_creator }
+
+          it 'is still authorized to show' do
+            expect(subject).to be(true)
+          end
+        end
+      end
+
+      context 'on a prediction created by that same user' do
+        let(:prediction) do
+          FactoryBot.create(
+            :prediction,
+            creator: user,
+            visibility: visibility
+          )
+        end
+
+        context 'that is public' do
+          let(:visibility) { :visible_to_everyone }
+
+          it 'is authorized to show' do
+            expect(subject).to be(true)
+          end
+        end
+
+        context 'that has been made private' do
+          let(:visibility) { :visible_to_creator }
+
+          it 'is still authorized to show' do
+            expect(subject).to be(true)
+          end
+        end
+      end
+    end
+
+    context 'for a user that has no previous history with a given prediction' do
+      let(:prediction) do
+        FactoryBot.create(
+          :prediction,
+          creator: another_user,
+          visibility: visibility
+        )
+      end
+
+      context 'but that prediction is public' do
+        let(:visibility) { :visible_to_everyone }
+
+        it 'is authorized to show' do
+          expect(subject).to be(true)
+        end
+      end
+
+      context 'and that prediction has been made private' do
+        let(:visibility) { :visible_to_creator }
+
+        it 'is not authorized to show' do
+          expect(subject).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, the following scenario is possible:

User A creates a public prediction.
User B wagers (or comments) on that prediction.
User A makes the prediction private.
The prediction becomes overdue.
User B will see the prediction on their list of overdue judgements.
User B will be unable to remove the prediction from said list because they lack permission to view (and therefore judge) the prediction.

This PR is intended to prevent this scenario by allowing users that wager (or comment) on a prediction to always be able to re-view or judge that prediction, while making it otherwise inaccessible to all other kinds of unauthorized users.

It should fix [this](https://github.com/tricycle/predictionbook/issues/143), [that](https://github.com/tricycle/predictionbook/issues/136), and [this other](https://github.com/tricycle/predictionbook/issues/104) issue.